### PR TITLE
Feat: 경매 입찰 조회/등록/취소 API 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,5 @@ dist
 ._.DS_Store
 **/.DS_Store
 **/._.DS_Store
+
+src/main/resources/application.yml

--- a/sql/init_schema.sql
+++ b/sql/init_schema.sql
@@ -68,14 +68,14 @@ CREATE TABLE auction_image
 -- 입찰 테이블
 CREATE TABLE bid
 (
-    id           BIGINT AUTO_INCREMENT PRIMARY KEY,
-    bidder_id    BIGINT NOT NULL,
-    auction_id   BIGINT NOT NULL,
-    price        INT    NOT NULL,
-    created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    cancelled_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    is_winning   BOOLEAN   DEFAULT FALSE,
-    is_deleted   BOOLEAN   DEFAULT FALSE,
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    bidder_id  BIGINT NOT NULL,
+    auction_id BIGINT NOT NULL,
+    price      INT    NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP,
+    is_winning BOOLEAN   DEFAULT FALSE,
+    is_deleted BOOLEAN   DEFAULT FALSE,
     FOREIGN KEY (bidder_id) REFERENCES user (id),
     FOREIGN KEY (auction_id) REFERENCES auction (id)
 );

--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/BidController.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/BidController.java
@@ -6,7 +6,7 @@ import com.samyookgoo.palgoosam.bid.controller.response.BidListResponse;
 import com.samyookgoo.palgoosam.bid.controller.response.BidResponse;
 import com.samyookgoo.palgoosam.bid.service.BidService;
 import com.samyookgoo.palgoosam.user.domain.User;
-import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -30,12 +30,9 @@ public class BidController {
     }
 
     @PostMapping("/{auctionId}/bids")
-    public BaseResponse<BidResponse> placeBid(@PathVariable Long auctionId, @RequestBody BidRequest request) {
-//        TODO: UserService 구현 후 수정 예정
-        User currentUser = User.builder()
-                .name("홍길동")
-                .email("hong@gmail.com")
-                .build();
+    public BaseResponse<BidResponse> placeBid(@PathVariable Long auctionId, @Valid @RequestBody BidRequest request) {
+        // TODO: 인증 사용자 연동 시 수정 필요
+        User currentUser = getDummyUser();
 
         BidResponse response = bidService.placeBid(auctionId, currentUser.getId(), request.getPrice());
         return BaseResponse.success(response);
@@ -43,15 +40,22 @@ public class BidController {
 
 
     @PatchMapping("/{auctionId}/bids/{bidId}")
-    public BaseResponse<String> cancelBid(@PathVariable Long auctionId, @PathVariable Long bidId,
-                                          HttpServletRequest request) {
-//        TODO: UserService 구현 후 수정 예정
-        User currentUser = User.builder()
-                .name("홍길동")
-                .email("hong@gmail.com")
-                .build();
+    public BaseResponse<String> cancelBid(@PathVariable Long auctionId, @PathVariable Long bidId) {
+        // TODO: 인증 사용자 연동 시 수정 필요
+        User currentUser = getDummyUser();
 
         bidService.cancelBid(auctionId, bidId, currentUser);
-        return BaseResponse.success("입찰");
+        return BaseResponse.success("입찰 취소 완료");
+    }
+
+    /**
+     * TODO: 로그인 연동 전 임시 유저 반환 (나중에 제거 예정)
+     */
+    private User getDummyUser() {
+        return User.builder()
+                .name("홍길동")
+                .email("hong@gmail.com")
+                .id(1L) // 실제 인증 시 제거 예정
+                .build();
     }
 }

--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/BidController.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/BidController.java
@@ -1,0 +1,24 @@
+package com.samyookgoo.palgoosam.bid.controller;
+
+import com.samyookgoo.palgoosam.bid.controller.response.BaseResponse;
+import com.samyookgoo.palgoosam.bid.controller.response.BidListResponse;
+import com.samyookgoo.palgoosam.bid.service.BidService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auctions")
+@RequiredArgsConstructor
+public class BidController {
+
+    private final BidService bidService;
+
+    @GetMapping("/{auctionId}/bids")
+    public BaseResponse<BidListResponse> auctionBids(@PathVariable Long auctionId) {
+        BidListResponse response = bidService.getBidsByAuctionId(auctionId);
+        return BaseResponse.success(response);
+    }
+}

--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/BidController.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/BidController.java
@@ -1,7 +1,9 @@
 package com.samyookgoo.palgoosam.bid.controller;
 
+import com.samyookgoo.palgoosam.bid.controller.request.BidRequest;
 import com.samyookgoo.palgoosam.bid.controller.response.BaseResponse;
 import com.samyookgoo.palgoosam.bid.controller.response.BidListResponse;
+import com.samyookgoo.palgoosam.bid.controller.response.BidResponse;
 import com.samyookgoo.palgoosam.bid.service.BidService;
 import com.samyookgoo.palgoosam.user.domain.User;
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,6 +28,19 @@ public class BidController {
         BidListResponse response = bidService.getBidsByAuctionId(auctionId);
         return BaseResponse.success(response);
     }
+
+    @PostMapping("/{auctionId}/bids")
+    public BaseResponse<BidResponse> placeBid(@PathVariable Long auctionId, @RequestBody BidRequest request) {
+//        TODO: UserService 구현 후 수정 예정
+        User currentUser = User.builder()
+                .name("홍길동")
+                .email("hong@gmail.com")
+                .build();
+
+        BidResponse response = bidService.placeBid(auctionId, currentUser.getId(), request.getPrice());
+        return BaseResponse.success(response);
+    }
+
 
     @PatchMapping("/{auctionId}/bids/{bidId}")
     public BaseResponse<String> cancelBid(@PathVariable Long auctionId, @PathVariable Long bidId,

--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/BidController.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/BidController.java
@@ -3,8 +3,11 @@ package com.samyookgoo.palgoosam.bid.controller;
 import com.samyookgoo.palgoosam.bid.controller.response.BaseResponse;
 import com.samyookgoo.palgoosam.bid.controller.response.BidListResponse;
 import com.samyookgoo.palgoosam.bid.service.BidService;
+import com.samyookgoo.palgoosam.user.domain.User;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,5 +23,18 @@ public class BidController {
     public BaseResponse<BidListResponse> auctionBids(@PathVariable Long auctionId) {
         BidListResponse response = bidService.getBidsByAuctionId(auctionId);
         return BaseResponse.success(response);
+    }
+
+    @PatchMapping("/{auctionId}/bids/{bidId}")
+    public BaseResponse<String> cancelBid(@PathVariable Long auctionId, @PathVariable Long bidId,
+                                          HttpServletRequest request) {
+//        TODO: UserService 구현 후 수정 예정
+        User currentUser = User.builder()
+                .name("홍길동")
+                .email("hong@gmail.com")
+                .build();
+
+        bidService.cancelBid(auctionId, bidId, currentUser);
+        return BaseResponse.success("입찰");
     }
 }

--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/request/BidRequest.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/request/BidRequest.java
@@ -1,5 +1,6 @@
 package com.samyookgoo.palgoosam.bid.controller.request;
 
+import com.samyookgoo.palgoosam.common.validation.DivisibleBy;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
@@ -8,5 +9,6 @@ import lombok.Data;
 public class BidRequest {
     @NotNull(message = "입찰 금액은 필수입니다.")
     @Min(value = 0, message = "입찰 금액은 0원 이상이어야 합니다.")
+    @DivisibleBy(value = 100, message = "입찰 금액은 100원 단위여야 합니다.")
     private Integer price;
 }

--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/request/BidRequest.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/request/BidRequest.java
@@ -1,0 +1,8 @@
+package com.samyookgoo.palgoosam.bid.controller.request;
+
+import lombok.Data;
+
+@Data
+public class BidRequest {
+    private Integer price;
+}

--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/request/BidRequest.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/request/BidRequest.java
@@ -1,8 +1,12 @@
 package com.samyookgoo.palgoosam.bid.controller.request;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
 public class BidRequest {
+    @NotNull(message = "입찰 금액은 필수입니다.")
+    @Min(value = 0, message = "입찰 금액은 0원 이상이어야 합니다.")
     private Integer price;
 }

--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BaseResponse.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BaseResponse.java
@@ -1,0 +1,23 @@
+package com.samyookgoo.palgoosam.bid.controller.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BaseResponse<T> {
+
+    private int code;
+    private String message;
+    private T data;
+
+    public static <T> BaseResponse<T> success(T body) {
+        return new BaseResponse<>(200, "success", body);
+    }
+
+    public static <T> BaseResponse<T> error(String message, T body) {
+        return new BaseResponse<>(400, message, body);
+    }
+}

--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidListResponse.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidListResponse.java
@@ -1,0 +1,15 @@
+package com.samyookgoo.palgoosam.bid.controller.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BidListResponse {
+    private Long auctionId;
+    private int totalBid;
+    private int totalBidder;
+    private List<BidResponse> bids;
+    private List<BidResponse> cancelledBids;
+}

--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidListResponse.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidListResponse.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 @Builder
 public class BidListResponse {
     private Long auctionId;
-    private int totalBid;
-    private int totalBidder;
+    private Integer totalBid;
+    private Integer totalBidder;
     private List<BidResponse> bids;
     private List<BidResponse> cancelledBids;
 }

--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidResponse.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidResponse.java
@@ -1,0 +1,14 @@
+package com.samyookgoo.palgoosam.bid.controller.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BidResponse {
+    private Long bidId;
+    private String bidderEmail;
+    private Integer bidPrice;
+    private String createdAt;
+    private String cancelledAt;
+}

--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidResponse.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidResponse.java
@@ -10,5 +10,5 @@ public class BidResponse {
     private String bidderEmail;
     private Integer bidPrice;
     private String createdAt;
-    private String cancelledAt;
+    private String updatedAt;
 }

--- a/src/main/java/com/samyookgoo/palgoosam/bid/domain/Bid.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/domain/Bid.java
@@ -10,15 +10,21 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
 
-@Getter
-@Setter
 @Entity
 @Table(name = "bid")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Bid {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/samyookgoo/palgoosam/bid/domain/Bid.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/domain/Bid.java
@@ -2,7 +2,9 @@ package com.samyookgoo.palgoosam.bid.domain;
 
 import com.samyookgoo.palgoosam.auction.domain.Auction;
 import com.samyookgoo.palgoosam.user.domain.User;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -17,6 +19,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Table(name = "bid")
@@ -30,20 +33,22 @@ public class Bid {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bidder_id", nullable = false)
     private User bidder;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "auction_id", nullable = false)
     private Auction auction;
 
     private int price;
 
     @CreationTimestamp
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    private LocalDateTime cancelledAt;
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
 
     @ColumnDefault("false")
     private Boolean isWinning = false;

--- a/src/main/java/com/samyookgoo/palgoosam/bid/domain/Bid.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/domain/Bid.java
@@ -10,9 +10,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.Getter;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
 
+@Getter
 @Entity
 @Table(name = "bid")
 public class Bid {

--- a/src/main/java/com/samyookgoo/palgoosam/bid/domain/Bid.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/domain/Bid.java
@@ -11,10 +11,12 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Getter
+@Setter
 @Entity
 @Table(name = "bid")
 public class Bid {

--- a/src/main/java/com/samyookgoo/palgoosam/bid/repository/BidRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/repository/BidRepository.java
@@ -2,8 +2,19 @@ package com.samyookgoo.palgoosam.bid.repository;
 
 import com.samyookgoo.palgoosam.bid.domain.Bid;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
 
 public interface BidRepository extends JpaRepository<Bid, Long> {
     List<Bid> findByAuctionIdOrderByCreatedAtDesc(Long auctionId);
+
+    @Query("SELECT MAX(b.price) FROM Bid b WHERE b.auction.id = :auctionId AND b.isDeleted = false")
+    Integer findMaxBidPriceByAuctionId(Long auctionId);
+
+    @Query("SELECT b FROM Bid b WHERE b.auction.id = :auctionId " +
+            "AND b.isDeleted = false " +
+            "ORDER BY b.price DESC LIMIT 1")
+    Optional<Bid> findTopValidBidByAuctionId(Long auctionId);
 }

--- a/src/main/java/com/samyookgoo/palgoosam/bid/repository/BidRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/repository/BidRepository.java
@@ -1,0 +1,9 @@
+package com.samyookgoo.palgoosam.bid.repository;
+
+import com.samyookgoo.palgoosam.bid.domain.Bid;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BidRepository extends JpaRepository<Bid, Long> {
+    List<Bid> findByAuctionIdOrderByCreatedAtDesc(Long auctionId);
+}

--- a/src/main/java/com/samyookgoo/palgoosam/bid/repository/BidRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/repository/BidRepository.java
@@ -17,4 +17,6 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
             "AND b.isDeleted = false " +
             "ORDER BY b.price DESC LIMIT 1")
     Optional<Bid> findTopValidBidByAuctionId(Long auctionId);
+
+    Optional<Bid> findByAuctionIdAndIsWinningTrue(Long auctionId);
 }

--- a/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
@@ -1,10 +1,13 @@
 package com.samyookgoo.palgoosam.bid.service;
 
+import com.samyookgoo.palgoosam.auction.domain.Auction;
+import com.samyookgoo.palgoosam.auction.repository.AuctionRepository;
 import com.samyookgoo.palgoosam.bid.controller.response.BidListResponse;
 import com.samyookgoo.palgoosam.bid.controller.response.BidResponse;
 import com.samyookgoo.palgoosam.bid.domain.Bid;
 import com.samyookgoo.palgoosam.bid.repository.BidRepository;
 import com.samyookgoo.palgoosam.user.domain.User;
+import com.samyookgoo.palgoosam.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -14,12 +17,16 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
 public class BidService {
     private final BidRepository bidRepository;
+    private final AuctionRepository auctionRepository;
+    private final UserRepository userRepository;
+
 //    TODO: auctionRepository 사용 예정
 //    private final AuctionRepository auctionRepository;
 
@@ -54,6 +61,47 @@ public class BidService {
                 .bids(bids)
                 .cancelledBids(cancelledBids)
                 .build();
+    }
+
+    @Transactional
+    public BidResponse placeBid(Long auctionId, Long userId, int price) {
+        Auction auction = auctionRepository.findById(auctionId)
+                .orElseThrow(() -> new NoSuchElementException("해당 경매를 찾을 수 없습니다."));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NoSuchElementException("해당 사용자를 찾을 수 없습니다."));
+
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isBefore(auction.getStartTime()) || now.isAfter(auction.getEndTime())) {
+            throw new IllegalStateException("현재는 입찰 가능한 시간이 아닙니다.");
+        }
+
+        if (auction.getBasePrice() > price) {
+            throw new IllegalArgumentException("시작가보다 높은 금액을 입력해야 합니다.");
+        }
+
+        Integer highestPrice = bidRepository.findMaxBidPriceByAuctionId(auctionId);
+        if (highestPrice != null && price <= highestPrice) {
+            throw new IllegalArgumentException("현재 최고가보다 높은 금액을 입력해야 합니다.");
+        }
+
+        Optional<Bid> prevWinningBidOpt = bidRepository.findByAuctionIdAndIsWinningTrue(auctionId);
+        prevWinningBidOpt.ifPresent(prev -> {
+            prev.setIsWinning(false);
+            bidRepository.save(prev);
+        });
+
+        Bid bid = Bid.builder()
+                .auction(auction)
+                .bidder(user)
+                .price(price)
+                .isWinning(Boolean.TRUE)
+                .isDeleted(Boolean.FALSE)
+                .build();
+
+        Bid savedBid = bidRepository.save(bid);
+
+        return mapToResponse(savedBid);
     }
 
     public void cancelBid(Long auctionId, Long bidId, User currentUser) {

--- a/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
@@ -1,0 +1,64 @@
+package com.samyookgoo.palgoosam.bid.service;
+
+import com.samyookgoo.palgoosam.bid.controller.response.BidListResponse;
+import com.samyookgoo.palgoosam.bid.controller.response.BidResponse;
+import com.samyookgoo.palgoosam.bid.domain.Bid;
+import com.samyookgoo.palgoosam.bid.repository.BidRepository;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BidService {
+    private final BidRepository bidRepository;
+//    TODO: auctionRepository 사용 예정
+//    private final AuctionRepository auctionRepository;
+
+    public BidListResponse getBidsByAuctionId(Long auctionId) {
+//        TODO: auctionRepository 사용 예정 - 경매 존재 여부 확인
+//        if (!auctionRepository.existsById(auctionId)) {
+//            throw new IllegalArgumentException("해당 경매를 찾을 수 없습니다.");
+//        }
+
+        List<Bid> allBids = bidRepository.findByAuctionIdOrderByCreatedAtDesc(auctionId);
+
+        List<BidResponse> bids = allBids.stream()
+                .filter(b -> b.getCancelledAt() == null)
+                .map(this::mapToResponse)
+                .toList();
+
+        List<BidResponse> cancelledBids = allBids.stream()
+                .filter(b -> b.getCancelledAt() != null)
+                .map(this::mapToResponse)
+                .toList();
+
+        int totalBid = allBids.size();
+        int totalBidder = (int) allBids.stream()
+                .map(b -> b.getBidder().getId())
+                .distinct()
+                .count();
+
+        return BidListResponse.builder()
+                .auctionId(auctionId)
+                .totalBid(totalBid)
+                .totalBidder(totalBidder)
+                .bids(bids)
+                .cancelledBids(cancelledBids)
+                .build();
+    }
+
+    private BidResponse mapToResponse(Bid bid) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+        return BidResponse.builder()
+                .bidId(bid.getId())
+                .bidderEmail(bid.getBidder().getEmail())
+                .bidPrice(bid.getPrice())
+                .createdAt(bid.getCreatedAt().format(formatter))
+                .cancelledAt(bid.getCancelledAt() != null ? bid.getCancelledAt().format(formatter) : null)
+                .build();
+    }
+
+}

--- a/src/main/java/com/samyookgoo/palgoosam/common/validation/DivisibleBy.java
+++ b/src/main/java/com/samyookgoo/palgoosam/common/validation/DivisibleBy.java
@@ -1,0 +1,23 @@
+package com.samyookgoo.palgoosam.common.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = DivisibleByValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DivisibleBy {
+    String message() default "금액은 {value}원 단위여야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    int value();
+}

--- a/src/main/java/com/samyookgoo/palgoosam/common/validation/DivisibleByValidator.java
+++ b/src/main/java/com/samyookgoo/palgoosam/common/validation/DivisibleByValidator.java
@@ -1,0 +1,19 @@
+package com.samyookgoo.palgoosam.common.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class DivisibleByValidator implements ConstraintValidator<DivisibleBy, Integer> {
+
+    private int unit;
+
+    @Override
+    public void initialize(DivisibleBy constraintAnnotation) {
+        this.unit = constraintAnnotation.value();
+    }
+
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        return value == null || value % unit == 0;
+    }
+}

--- a/src/main/java/com/samyookgoo/palgoosam/user/repository/UserRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/user/repository/UserRepository.java
@@ -1,0 +1,2 @@
+package com.samyookgoo.palgoosam.user.repository;public interface UserRepository {
+}

--- a/src/main/java/com/samyookgoo/palgoosam/user/repository/UserRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/user/repository/UserRepository.java
@@ -1,2 +1,0 @@
-package com.samyookgoo.palgoosam.user.repository;public interface UserRepository {
-}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
       hibernate:
         format_sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
 
   logging:
     level:


### PR DESCRIPTION
### ✅  PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 🎯요약(Summary)
- 경매 입찰 내역 조회 API 구현
- 경매 입찰 취소 API 구현
- 경매 입찰 API 구현

### 💻 상세 내용(Describe your changes)
- 경매 입찰 내역 조회 API 구현
     - 경매 ID로 해당 입찰 내역 목록을 조회
     - 유효 입찰, 취소된 입찰을 구분하여 응답 (입찰자 수, 총 입찰 수 포함)

- 경매 입찰 등록 API 구현
     - 사용자는 진행 중인 경매에 입찰 가능
     - 입찰 금액은 시작가 이상, 현재 최고가 초과, 100원 단위여야 함

- 경매 입찰 취소 API 구현
     - 본인 입찰만 취소 가능하며, 입찰 후 1분 이내인 경우만 허용
     - 최고 입찰가가 아닌 경우에는 취소 불가
     - 취소 시 다음 유효 입찰을 자동 낙찰 처리

### 📌 관련 이슈번호(Related Issue)
close #22 
close #25 
close #30 

