### PR TITLE
hotfix: auction controller와 auction iamge 수정, API 명세대로 반환하도록 검색 API 수정

### DIFF
--- a/src/main/java/com/samyookgoo/palgoosam/auction/controller/AuctionController.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/controller/AuctionController.java
@@ -25,10 +25,11 @@ public class AuctionController {
 
     private final AuctionService auctionService;
     private final FileStore fileStore;
-  
+
     @GetMapping("/search")
     public ResponseEntity<List<AuctionSearchResponseDto>> search(AuctionSearchRequestDto auctionSearchRequestDto) {
         return ResponseEntity.status(HttpStatus.OK).body(auctionService.search(auctionSearchRequestDto));
+    }
 
     @PostMapping
     public ResponseEntity<?> createAuction(

--- a/src/main/java/com/samyookgoo/palgoosam/auction/controller/AuctionController.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/controller/AuctionController.java
@@ -7,6 +7,7 @@ import com.samyookgoo.palgoosam.auction.dto.AuctionSearchResponseDto;
 import com.samyookgoo.palgoosam.auction.file.FileStore;
 import com.samyookgoo.palgoosam.auction.file.ResultFileStore;
 import com.samyookgoo.palgoosam.auction.service.AuctionService;
+import com.samyookgoo.palgoosam.common.response.BaseResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -27,8 +28,10 @@ public class AuctionController {
     private final FileStore fileStore;
 
     @GetMapping("/search")
-    public ResponseEntity<List<AuctionSearchResponseDto>> search(AuctionSearchRequestDto auctionSearchRequestDto) {
-        return ResponseEntity.status(HttpStatus.OK).body(auctionService.search(auctionSearchRequestDto));
+    public ResponseEntity<BaseResponse<AuctionSearchResponseDto>> search(
+            AuctionSearchRequestDto auctionSearchRequestDto) {
+        return ResponseEntity.status(HttpStatus.OK).body(BaseResponse.success("정상적으로 조회되었습니다.",
+                auctionService.search(auctionSearchRequestDto)));
     }
 
     @PostMapping

--- a/src/main/java/com/samyookgoo/palgoosam/auction/domain/AuctionImage.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/domain/AuctionImage.java
@@ -10,8 +10,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
@@ -21,6 +23,8 @@ import org.hibernate.annotations.CreationTimestamp;
 @Builder
 @Entity
 @Table(name = "auction_image")
+@AllArgsConstructor
+@NoArgsConstructor
 public class AuctionImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/samyookgoo/palgoosam/auction/domain/AuctionImage.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/domain/AuctionImage.java
@@ -48,6 +48,6 @@ public class AuctionImage {
     @CreationTimestamp
     private LocalDateTime createdAt;
 
-    //    @Column(nullable = false, length = 255)
-    //    private String url;
+    @Column(nullable = false, length = 255)
+    private String url;
 }

--- a/src/main/java/com/samyookgoo/palgoosam/auction/dto/AuctionListItemDto.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/dto/AuctionListItemDto.java
@@ -1,0 +1,31 @@
+package com.samyookgoo.palgoosam.auction.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class AuctionListItemDto {
+    private Long id;
+    private String title;
+
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+
+    private String status;
+
+    private Integer basePrice;
+    private Integer currentPrice;
+
+    private Integer bidderCount;
+
+    private Integer scrapCount;
+
+    private String thumbnailUrl;
+
+    // 로그인 구현에 따라 수정 필요
+    private Boolean isScrapped = false;
+}

--- a/src/main/java/com/samyookgoo/palgoosam/auction/dto/AuctionSearchResponseDto.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/dto/AuctionSearchResponseDto.java
@@ -1,31 +1,15 @@
 package com.samyookgoo.palgoosam.auction.dto;
 
-import java.time.LocalDateTime;
-import lombok.Builder;
+import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-@Builder
+@AllArgsConstructor
 public class AuctionSearchResponseDto {
-    private Long id;
-    private String title;
+    private Long totalAuctionsCount;
 
-    private LocalDateTime startTime;
-    private LocalDateTime endTime;
-
-    private String status;
-
-    private Integer basePrice;
-    private Integer currentPrice;
-
-    private Integer bidderCount;
-
-    private Integer scrapCount;
-
-    private String thumbnailUrl;
-
-    // 로그인 구현에 따라 수정 필요
-    private Boolean isScrapped = false;
+    private List<AuctionListItemDto> auctionList;
 }

--- a/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
@@ -2,10 +2,11 @@ package com.samyookgoo.palgoosam.auction.service;
 
 import com.samyookgoo.palgoosam.auction.domain.Auction;
 import com.samyookgoo.palgoosam.auction.domain.AuctionImage;
-import com.samyookgoo.palgoosam.auction.dto.AuctionSearchRequestDto;
-import com.samyookgoo.palgoosam.auction.dto.AuctionSearchResponseDto;
 import com.samyookgoo.palgoosam.auction.domain.Category;
 import com.samyookgoo.palgoosam.auction.dto.AuctionCreateRequest;
+import com.samyookgoo.palgoosam.auction.dto.AuctionListItemDto;
+import com.samyookgoo.palgoosam.auction.dto.AuctionSearchRequestDto;
+import com.samyookgoo.palgoosam.auction.dto.AuctionSearchResponseDto;
 import com.samyookgoo.palgoosam.auction.file.ResultFileStore;
 import com.samyookgoo.palgoosam.auction.repository.AuctionImageRepository;
 import com.samyookgoo.palgoosam.auction.repository.AuctionRepository;
@@ -13,16 +14,16 @@ import com.samyookgoo.palgoosam.auction.repository.CategoryRepository;
 import com.samyookgoo.palgoosam.bid.domain.Bid;
 import com.samyookgoo.palgoosam.bid.repository.BidRepository;
 import com.samyookgoo.palgoosam.user.domain.Scrap;
-import com.samyookgoo.palgoosam.user.repository.ScrapRepository;
 import com.samyookgoo.palgoosam.user.domain.User;
+import com.samyookgoo.palgoosam.user.repository.ScrapRepository;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -93,17 +94,17 @@ public class AuctionService {
         auction.setAuctionImages(auctionImages);
         return auctionRepository.save(auction);
     }
-  
-    
-    public List<AuctionSearchResponseDto> search(AuctionSearchRequestDto auctionSearchRequestDto) {
-        log.info("다음 조건을 검색: {}", auctionSearchRequestDto.toString());
 
+
+    public AuctionSearchResponseDto search(AuctionSearchRequestDto auctionSearchRequestDto) {
+        log.info("다음 조건을 검색: {}", auctionSearchRequestDto.toString());
         List<Auction> auctionList = findAuctionList(auctionSearchRequestDto);
+        Long auctionCount = Long.valueOf(auctionList.size());
 
         log.info("{}개의 경매를 찾았습니다.", auctionList.size());
 
-        if(auctionList.isEmpty()) {
-            return new ArrayList<>();
+        if (auctionList.isEmpty()) {
+            return new AuctionSearchResponseDto(auctionCount, new ArrayList<>());
         }
 
         auctionList.forEach(auction -> log.debug("찾은 경매 정보: {}", auction.toString()));
@@ -113,12 +114,12 @@ public class AuctionService {
         Map<Long, List<Bid>> bidsByAuctionMap = getBidListByAuctionMap(auctionIdList);
         Map<Long, List<Scrap>> scrapsByAuctionMap = getScrapListByAuctionMap(auctionIdList);
 
-        List<AuctionSearchResponseDto> resultWithoutSort = auctionList.stream().map(auction -> {
+        List<AuctionListItemDto> resultWithoutSort = auctionList.stream().map(auction -> {
                     Long auctionId = auction.getId();
                     String thumbnailUrl = thumbnailMap.get(auctionId);
                     List<Bid> bids = bidsByAuctionMap.get(auctionId);
                     List<Scrap> scraps = scrapsByAuctionMap.get(auctionId);
-                    return AuctionSearchResponseDto.builder().id(auction.getId())
+                    return AuctionListItemDto.builder().id(auction.getId())
                             .title(auction.getTitle())
                             .startTime(auction.getStartTime())
                             .endTime(auction.getEndTime())
@@ -133,7 +134,8 @@ public class AuctionService {
                 }
         ).toList();
 
-        return this.sortAuctionSearchResponseDtoList(resultWithoutSort, auctionSearchRequestDto.getSortBy());
+        return new AuctionSearchResponseDto(auctionCount,
+                this.sortAuctionListItemDtoList(resultWithoutSort, auctionSearchRequestDto.getSortBy()));
     }
 
     private List<Auction> findAuctionList(AuctionSearchRequestDto auctionSearchRequestDto) {
@@ -169,21 +171,21 @@ public class AuctionService {
                 .collect(Collectors.groupingBy(scrap -> scrap.getAuction().getId()));
     }
 
-    private List<AuctionSearchResponseDto> sortAuctionSearchResponseDtoList(
-            List<AuctionSearchResponseDto> auctionSearchResponseDtoList, String sortBy
+    private List<AuctionListItemDto> sortAuctionListItemDtoList(
+            List<AuctionListItemDto> auctionSearchResponseDtoList, String sortBy
     ) {
         if (sortBy.equals("price_asc")) {
             return auctionSearchResponseDtoList.stream()
-                    .sorted(Comparator.comparing(AuctionSearchResponseDto::getBasePrice)).toList();
+                    .sorted(Comparator.comparing(AuctionListItemDto::getBasePrice)).toList();
         } else if (sortBy.equals("price_desc")) {
             return auctionSearchResponseDtoList.stream()
-                    .sorted(Comparator.comparing(AuctionSearchResponseDto::getBasePrice).reversed()).toList();
+                    .sorted(Comparator.comparing(AuctionListItemDto::getBasePrice).reversed()).toList();
         } else if (sortBy.equals("scrap_count_desc")) {
             return auctionSearchResponseDtoList.stream()
-                    .sorted(Comparator.comparing(AuctionSearchResponseDto::getScrapCount).reversed()).toList();
+                    .sorted(Comparator.comparing(AuctionListItemDto::getScrapCount).reversed()).toList();
         } else if (sortBy.equals("bidder_count_desc")) {
             return auctionSearchResponseDtoList.stream()
-                    .sorted(Comparator.comparing(AuctionSearchResponseDto::getBidderCount).reversed()).toList();
+                    .sorted(Comparator.comparing(AuctionListItemDto::getBidderCount).reversed()).toList();
         }
 
         return auctionSearchResponseDtoList;

--- a/src/main/java/com/samyookgoo/palgoosam/common/response/BaseResponse.java
+++ b/src/main/java/com/samyookgoo/palgoosam/common/response/BaseResponse.java
@@ -1,0 +1,23 @@
+package com.samyookgoo.palgoosam.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BaseResponse<T> {
+
+    private int code;
+    private String message;
+    private T data;
+
+    public static <T> BaseResponse<T> success(String message, T body) {
+        return new BaseResponse<>(200, message, body);
+    }
+
+    public static <T> BaseResponse<T> error(String message, T body) {
+        return new BaseResponse<>(400, message, body);
+    }
+}

--- a/src/main/java/com/samyookgoo/palgoosam/user/domain/UserFcmToken.java
+++ b/src/main/java/com/samyookgoo/palgoosam/user/domain/UserFcmToken.java
@@ -14,8 +14,8 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
-@Table(name = "user_notification_token")
-public class UserNotificationToken {
+@Table(name = "user_fcm_token")
+public class UserFcmToken {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;


### PR DESCRIPTION
### ✅  PR Type

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [x] Other… Please describe: hotfix

### 🎯요약(Summary)
- auctionController에 누락되어 있던 `{`추가 (github에서 충돌 수정하다가 제가 실수로 삭제시킨 것 같습니다.)
- auction image에서 url이 주석처리 되어 service 동작이 안되던 부분 수정
- 의도하지는 않았는데, user_notification_token 테이블 명을 user_fcm_token으로 수정한 부분이 같이 커밋에 반영되었네요... 
잘못 올렸는데 취소할 방법이 없어서 일단 이 PR에 포함시켰습니다.

- 지연님 코드 리뷰를 하다가 검색 API를 API 명세대로 반환하지 않았음을 발견했습니다. 그 부분을 수정하여 이번 PR에 추가했습니다.

### 💻 상세 내용(Describe your changes)


### 📌 관련 이슈번호(Related Issue)
close #5 