### PR TITLE
Hotfix: User 및 AuctionImage 엔티티의 어노테이션 정리 및 중복 제거

### DIFF
--- a/src/main/java/com/samyookgoo/palgoosam/auction/domain/AuctionImage.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/domain/AuctionImage.java
@@ -24,8 +24,6 @@ import org.hibernate.annotations.CreationTimestamp;
 @AllArgsConstructor
 @Entity
 @Table(name = "auction_image")
-@AllArgsConstructor
-@NoArgsConstructor
 public class AuctionImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/samyookgoo/palgoosam/user/domain/User.java
+++ b/src/main/java/com/samyookgoo/palgoosam/user/domain/User.java
@@ -9,14 +9,20 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 
-@Getter
-@Setter
 @Entity
 @Table(name = "user")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
### ✅  PR Type
- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 🎯요약(Summary)
- User와 AuctionImage 엔티티의 Lombok 어노테이션을 정리하고, 중복 선언된 생성자 어노테이션을 제거했습니다.


### 💻 상세 내용(Describe your changes)
- User 엔티티에 @NoArgsConstructor, @AllArgsConstructor, @Builder 어노테이션 추가
- AuctionImage 엔티티에서 중복 선언된 @NoArgsConstructor, @AllArgsConstructor 제거


### 📌 관련 이슈번호(Related Issue)
- 해당 이슈 없음 (develop 브랜치 PR 머지 후 pull 받아 실행 중 컴파일 에러로 발견)
