### PR TITLE
Feat 경매 상품 주문페이지 조회 API 구

### DIFF
--- a/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionImageRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionImageRepository.java
@@ -2,11 +2,9 @@ package com.samyookgoo.palgoosam.auction.repository;
 
 import com.samyookgoo.palgoosam.auction.domain.AuctionImage;
 import com.samyookgoo.palgoosam.bid.projection.MainImageProjection;
-import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -24,11 +22,6 @@ public interface AuctionImageRepository extends JpaRepository<AuctionImage, Long
                   AND ai.imageSeq = 0
             """)
     List<MainImageProjection> findPrjMainImagesByAuctionIds(@Param("auctionIds") List<Long> auctionIds);
-
-    @Transactional
-    @Modifying
-    @Query("DELETE FROM AuctionImage a WHERE a.auction.id = :auctionId")
-    void deleteByAuctionId(@Param("auctionId") Long auctionId);
 
     @Query("SELECT a FROM AuctionImage a " +
             "WHERE a.auction.id = :auctionId AND a.imageSeq = 0")

--- a/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
@@ -364,15 +364,15 @@ public class AuctionService {
 
     @Transactional(readOnly = true)
     public List<RelatedAuctionResponse> getRelatedAuctions(Long auctionId) {
-        Auction baseAuction = auctionRepository.findById(auctionId)
+        Auction auction = auctionRepository.findById(auctionId)
                 .orElseThrow(() -> new NoSuchElementException("경매 상품이 존재하지 않습니다."));
 
         Long loginUserId = getLoginUserId();
 
-        Long detailCategoryId = baseAuction.getCategory().getId();
+        Long detailCategoryId = auction.getCategory().getId();
 
-        Long subCategoryId = baseAuction.getCategory().getParent() != null
-                ? baseAuction.getCategory().getParent().getId()
+        Long subCategoryId = auction.getCategory().getParent() != null
+                ? auction.getCategory().getParent().getId()
                 : null;
 
         List<Auction> detailCategoryList = auctionRepository.findByCategoryIdAndStatus(detailCategoryId,

--- a/src/main/java/com/samyookgoo/palgoosam/deliveryaddress/dto/DeliveryAddressResponseDto.java
+++ b/src/main/java/com/samyookgoo/palgoosam/deliveryaddress/dto/DeliveryAddressResponseDto.java
@@ -2,11 +2,13 @@ package com.samyookgoo.palgoosam.deliveryaddress.dto;
 
 import com.samyookgoo.palgoosam.deliveryaddress.domain.DeliveryAddress;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
 @AllArgsConstructor
 public class DeliveryAddressResponseDto {
     private Long id;

--- a/src/main/java/com/samyookgoo/palgoosam/deliveryaddress/repository/DeliveryAddressRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/deliveryaddress/repository/DeliveryAddressRepository.java
@@ -2,34 +2,36 @@ package com.samyookgoo.palgoosam.deliveryaddress.repository;
 
 import com.samyookgoo.palgoosam.deliveryaddress.domain.DeliveryAddress;
 import com.samyookgoo.palgoosam.user.domain.User;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Optional;
-
 public interface DeliveryAddressRepository extends JpaRepository<DeliveryAddress, Long> {
     @Modifying(clearAutomatically = true)
     @Transactional
     @Query("""
-        UPDATE DeliveryAddress d
-           SET d.isDefault = false
-         WHERE d.user.id = :userId
-    """)
+                UPDATE DeliveryAddress d
+                   SET d.isDefault = false
+                 WHERE d.user.id = :userId
+            """)
     int unsetAllDefaults(@Param("userId") Long userId);
 
     @Modifying(clearAutomatically = true)
     @Transactional
     @Query("""
-    UPDATE DeliveryAddress d
-      SET d.isDefault = true
-    WHERE d.id = :id AND d.user.id = :userId
-""")
+                UPDATE DeliveryAddress d
+                  SET d.isDefault = true
+                WHERE d.id = :id AND d.user.id = :userId
+            """)
     int updateDefault(@Param("id") Long id, @Param("userId") Long userId);
 
     List<DeliveryAddress> findAllByUser_Id(Long userId);
+
     Optional<DeliveryAddress> findByUserAndId(User user, Long addressId);
+
+    Optional<DeliveryAddress> findDefaultByUserId(Long userId);
 }

--- a/src/main/java/com/samyookgoo/palgoosam/payment/controller/OrderController.java
+++ b/src/main/java/com/samyookgoo/palgoosam/payment/controller/OrderController.java
@@ -1,0 +1,32 @@
+package com.samyookgoo.palgoosam.payment.controller;
+
+import com.samyookgoo.palgoosam.auth.service.AuthService;
+import com.samyookgoo.palgoosam.common.response.BaseResponse;
+import com.samyookgoo.palgoosam.payment.controller.response.OrderResponse;
+import com.samyookgoo.palgoosam.payment.service.PaymentService;
+import com.samyookgoo.palgoosam.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auctions")
+public class OrderController {
+    private final PaymentService paymentService;
+    private final AuthService authService;
+
+    @GetMapping("/{auctionId}/orders")
+    public ResponseEntity<BaseResponse<OrderResponse>> getOrderPage(@PathVariable Long auctionId) {
+        User user = authService.getCurrentUser();
+
+        OrderResponse response = paymentService.getOrder(auctionId, user.getId());
+        return ResponseEntity.ok(BaseResponse.success("주문 정보 조회 성공", response)
+        );
+    }
+
+}
+

--- a/src/main/java/com/samyookgoo/palgoosam/payment/controller/response/OrderResponse.java
+++ b/src/main/java/com/samyookgoo/palgoosam/payment/controller/response/OrderResponse.java
@@ -1,0 +1,20 @@
+package com.samyookgoo.palgoosam.payment.controller.response;
+
+import com.samyookgoo.palgoosam.deliveryaddress.dto.DeliveryAddressResponseDto;
+import com.samyookgoo.palgoosam.payment.domain.PaymentMethod;
+import com.samyookgoo.palgoosam.payment.domain.PaymentStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OrderResponse {
+    private String orderId;
+    private Long auctionId;
+    private String auctionTitle;
+    private String auctionThumbnail;
+    private Integer finalPrice;
+    private DeliveryAddressResponseDto deliveryAddress;
+    private PaymentMethod paymentMethod;
+    private PaymentStatus paymentStatus;
+}

--- a/src/main/java/com/samyookgoo/palgoosam/payment/service/PaymentService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/payment/service/PaymentService.java
@@ -1,10 +1,16 @@
 package com.samyookgoo.palgoosam.payment.service;
 
 import com.samyookgoo.palgoosam.auction.domain.Auction;
+import com.samyookgoo.palgoosam.auction.domain.AuctionImage;
+import com.samyookgoo.palgoosam.auction.repository.AuctionImageRepository;
 import com.samyookgoo.palgoosam.auction.repository.AuctionRepository;
 import com.samyookgoo.palgoosam.bid.domain.Bid;
 import com.samyookgoo.palgoosam.bid.repository.BidRepository;
+import com.samyookgoo.palgoosam.deliveryaddress.domain.DeliveryAddress;
+import com.samyookgoo.palgoosam.deliveryaddress.dto.DeliveryAddressResponseDto;
+import com.samyookgoo.palgoosam.deliveryaddress.repository.DeliveryAddressRepository;
 import com.samyookgoo.palgoosam.payment.controller.request.CreatePaymentRequest;
+import com.samyookgoo.palgoosam.payment.controller.response.OrderResponse;
 import com.samyookgoo.palgoosam.payment.controller.response.PaymentResponse;
 import com.samyookgoo.palgoosam.payment.domain.Payment;
 import com.samyookgoo.palgoosam.payment.domain.PaymentStatus;
@@ -15,6 +21,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 @Service
@@ -23,6 +30,8 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final AuctionRepository auctionRepository;
     private final BidRepository bidRepository;
+    private final DeliveryAddressRepository deliveryAddressRepository;
+    private final AuctionImageRepository auctionImageRepository;
 
     public PaymentResponse createPayment(Long auctionId, User buyer, CreatePaymentRequest request) {
         Auction auction = auctionRepository.findById(auctionId)
@@ -70,6 +79,38 @@ public class PaymentService {
                 .customerName(buyer.getName())
                 .customerMobilePhone(request.getPhoneNumber())
                 .finalPrice(request.getFinalPrice())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public OrderResponse getOrder(Long auctionId, Long userId) {
+        Auction auction = auctionRepository.findById(auctionId)
+                .orElseThrow(() -> new NoSuchElementException("경매 상품이 존재하지 않습니다."));
+
+        Bid winningBid = bidRepository.findByAuctionIdAndIsWinningTrue(auctionId)
+                .orElseThrow(() -> new IllegalStateException("낙찰된 입찰이 존재하지 않습니다."));
+
+        if (!winningBid.getBidder().getId().equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "낙찰자만 결제할 수 있습니다.");
+        }
+
+        DeliveryAddress deliveryAddress = deliveryAddressRepository.findDefaultByUserId(userId)
+                .orElseThrow(() -> new IllegalStateException("기본 배송지가 없습니다."));
+
+        String orderNumber = generateOrderNumber(auctionId);
+
+        AuctionImage image = auctionImageRepository.findMainImageByAuctionId(auctionId)
+                .orElseThrow(() -> new IllegalStateException("해당 경매에 대한 대표 이미지가 존재하지 않습니다."));
+
+        return OrderResponse.builder()
+                .orderId(orderNumber)
+                .auctionId(auction.getId())
+                .auctionTitle(auction.getTitle())
+                .auctionThumbnail(image != null ? image.getUrl() : null)
+                .finalPrice(winningBid.getPrice())
+                .deliveryAddress(DeliveryAddressResponseDto.of(deliveryAddress))
+                .paymentMethod(null) // 아직 선택되지 않음
+                .paymentStatus(PaymentStatus.READY)
                 .build();
     }
 


### PR DESCRIPTION
### ✅  PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 🎯요약(Summary)
경매 낙찰 이후 사용자가 결제 전 주문 정보를 확인할 수 있도록 주문 페이지 조회 가능함

### 💻 상세 내용(Describe your changes)
경매 ID, 제목, 썸네일
낙찰 금액
배송지 정보
결제 수단
주문 상태

### 📌 관련 이슈번호(Related Issue)
closes #68 