### PR TITLE
Refactor: authService를 통해 로그인 사용자를 가져오도록 코드 수정

### DIFF
--- a/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
@@ -22,6 +22,7 @@ import com.samyookgoo.palgoosam.auction.file.ResultFileStore;
 import com.samyookgoo.palgoosam.auction.repository.AuctionImageRepository;
 import com.samyookgoo.palgoosam.auction.repository.AuctionRepository;
 import com.samyookgoo.palgoosam.auction.repository.CategoryRepository;
+import com.samyookgoo.palgoosam.auth.service.AuthService;
 import com.samyookgoo.palgoosam.bid.domain.Bid;
 import com.samyookgoo.palgoosam.bid.repository.BidRepository;
 import com.samyookgoo.palgoosam.payment.domain.Payment;
@@ -29,6 +30,7 @@ import com.samyookgoo.palgoosam.user.domain.Scrap;
 import com.samyookgoo.palgoosam.user.domain.User;
 import com.samyookgoo.palgoosam.user.repository.ScrapRepository;
 import com.samyookgoo.palgoosam.user.repository.UserRepository;
+import com.samyookgoo.palgoosam.user.service.UserService;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -58,6 +60,8 @@ public class AuctionService {
     private final ScrapRepository scrapRepository;
     private final FileStore fileStore;
     private final BidRepository bidRepository;
+    private final UserService userService;
+    private final AuthService authService;
 
     public List<Long> getAuctionIdsByAuctions(List<Auction> auctions) {
         return auctions.stream()
@@ -465,26 +469,52 @@ public class AuctionService {
         Map<Long, String> thumbnailMap = getThumbnailMap(auctionIdList);
         Map<Long, List<Bid>> bidsByAuctionMap = getBidListByAuctionMap(auctionIdList);
         Map<Long, List<Scrap>> scrapsByAuctionMap = getScrapListByAuctionMap(auctionIdList);
+        User user = authService.getCurrentUser();
+        List<AuctionListItemDto> resultWithoutSort;
+        if (user == null) {
+            resultWithoutSort = auctionList.stream().map(auction -> {
+                        Long auctionId = auction.getId();
+                        String thumbnailUrl = thumbnailMap.get(auctionId);
+                        List<Bid> bids = bidsByAuctionMap.get(auctionId);
+                        List<Scrap> scraps = scrapsByAuctionMap.get(auctionId);
+                        return AuctionListItemDto.builder().id(auction.getId())
+                                .title(auction.getTitle())
+                                .startTime(auction.getStartTime())
+                                .endTime(auction.getEndTime())
+                                .status(auction.getStatus())
+                                .basePrice(auction.getBasePrice())
+                                .thumbnailUrl(thumbnailUrl)
+                                .bidderCount((long) (bids != null ? bids.size() : 0))
+                                .currentPrice(bids != null ? bids.getFirst().getPrice() : auction.getBasePrice())
+                                .scrapCount((long) (scraps != null ? scraps.size() : 0))
+                                .isScrapped(false)
+                                .build();
+                    }
+            ).toList();
+        } else {
+            Map<Long, Scrap> isScrappedMap = scrapRepository.findAllByUser_Id(user.getId()).stream()
+                    .collect(Collectors.toMap(scrap -> scrap.getAuction().getId(), scrap -> scrap));
+            resultWithoutSort = auctionList.stream().map(auction -> {
+                        Long auctionId = auction.getId();
+                        String thumbnailUrl = thumbnailMap.get(auctionId);
+                        List<Bid> bids = bidsByAuctionMap.get(auctionId);
+                        List<Scrap> scraps = scrapsByAuctionMap.get(auctionId);
 
-        List<AuctionListItemDto> resultWithoutSort = auctionList.stream().map(auction -> {
-                    Long auctionId = auction.getId();
-                    String thumbnailUrl = thumbnailMap.get(auctionId);
-                    List<Bid> bids = bidsByAuctionMap.get(auctionId);
-                    List<Scrap> scraps = scrapsByAuctionMap.get(auctionId);
-                    return AuctionListItemDto.builder().id(auction.getId())
-                            .title(auction.getTitle())
-                            .startTime(auction.getStartTime())
-                            .endTime(auction.getEndTime())
-                            .status(auction.getStatus())
-                            .basePrice(auction.getBasePrice())
-                            .thumbnailUrl(thumbnailUrl)
-                            .bidderCount((long) (bids != null ? bids.size() : 0))
-                            .currentPrice(bids != null ? bids.getFirst().getPrice() : auction.getBasePrice())
-                            .scrapCount((long) (scraps != null ? scraps.size() : 0))
-//                        .isScrapped(auctionSearchResult.getIsScrapped()) <- 로그인 구현 이후 기능 추가 필요
-                            .build();
-                }
-        ).toList();
+                        return AuctionListItemDto.builder().id(auction.getId())
+                                .title(auction.getTitle())
+                                .startTime(auction.getStartTime())
+                                .endTime(auction.getEndTime())
+                                .status(auction.getStatus())
+                                .basePrice(auction.getBasePrice())
+                                .thumbnailUrl(thumbnailUrl)
+                                .bidderCount((long) (bids != null ? bids.size() : 0))
+                                .currentPrice(bids != null ? bids.getFirst().getPrice() : auction.getBasePrice())
+                                .scrapCount((long) (scraps != null ? scraps.size() : 0))
+                                .isScrapped(isScrappedMap.get(auctionId) != null)
+                                .build();
+                    }
+            ).toList();
+        }
 
         return new AuctionSearchResponseDto(auctionCount,
                 this.sortAuctionListItemDtoList(resultWithoutSort, auctionSearchRequestDto.getSortBy()).stream()

--- a/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
@@ -30,7 +30,6 @@ import com.samyookgoo.palgoosam.user.domain.Scrap;
 import com.samyookgoo.palgoosam.user.domain.User;
 import com.samyookgoo.palgoosam.user.repository.ScrapRepository;
 import com.samyookgoo.palgoosam.user.repository.UserRepository;
-import com.samyookgoo.palgoosam.user.service.UserService;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -60,7 +59,6 @@ public class AuctionService {
     private final ScrapRepository scrapRepository;
     private final FileStore fileStore;
     private final BidRepository bidRepository;
-    private final UserService userService;
     private final AuthService authService;
 
     public List<Long> getAuctionIdsByAuctions(List<Auction> auctions) {

--- a/src/main/java/com/samyookgoo/palgoosam/auth/service/AuthService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auth/service/AuthService.java
@@ -4,7 +4,6 @@ import com.samyookgoo.palgoosam.user.domain.User;
 import com.samyookgoo.palgoosam.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,13 +11,15 @@ import org.springframework.stereotype.Service;
 public class AuthService {
     private final UserRepository userRepository;
 
-    /** SecurityContext 에 저장된 authentication 으로부터 User 엔티티 조회 */
+    /**
+     * SecurityContext 에 저장된 authentication 으로부터 User 엔티티 조회
+     */
     public User getCurrentUser() {
         String providerId = SecurityContextHolder
                 .getContext()
                 .getAuthentication()
                 .getName();
         return userRepository.findByProviderId(providerId)
-                .orElseThrow(() -> new UsernameNotFoundException(providerId));
+                .orElse(null);
     }
 }

--- a/src/main/java/com/samyookgoo/palgoosam/notification/controller/NotificationController.java
+++ b/src/main/java/com/samyookgoo/palgoosam/notification/controller/NotificationController.java
@@ -1,5 +1,7 @@
 package com.samyookgoo.palgoosam.notification.controller;
 
+import com.samyookgoo.palgoosam.auction.repository.AuctionImageRepository;
+import com.samyookgoo.palgoosam.auction.repository.AuctionRepository;
 import com.samyookgoo.palgoosam.common.response.BaseResponse;
 import com.samyookgoo.palgoosam.notification.dto.NotificationResponseDto;
 import com.samyookgoo.palgoosam.notification.service.NotificationService;
@@ -22,6 +24,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationController {
 
     private final NotificationService notificationService;
+    private final AuctionRepository auctionRepository;
+    private final AuctionImageRepository auctionImageRepository;
 
     @PostMapping("/fcm-token")
     public ResponseEntity<BaseResponse> saveFcmToken(@RequestBody String fcmToken) {
@@ -39,14 +43,14 @@ public class NotificationController {
     }
 
     @PatchMapping("/{notificationId}")
-    public ResponseEntity<BaseResponse> readNotification(@PathVariable Long notificationId) {
+    public ResponseEntity<BaseResponse<Void>> readNotification(@PathVariable Long notificationId) {
         notificationService.readNotification(notificationId);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new BaseResponse<>(200, "알림이 정상적으로 읽음 처리되었습니다.", null));
     }
 
     @DeleteMapping("/{notificationId}")
-    public ResponseEntity<BaseResponse> deleteNotification(@PathVariable Long notificationId) {
+    public ResponseEntity<BaseResponse<Void>> deleteNotification(@PathVariable Long notificationId) {
         notificationService.deleteNorification(notificationId);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new BaseResponse<>(200, "알림이 정상적으로 삭제되었습니다.", null));

--- a/src/main/java/com/samyookgoo/palgoosam/notification/controller/NotificationController.java
+++ b/src/main/java/com/samyookgoo/palgoosam/notification/controller/NotificationController.java
@@ -1,7 +1,5 @@
 package com.samyookgoo.palgoosam.notification.controller;
 
-import com.samyookgoo.palgoosam.auction.repository.AuctionImageRepository;
-import com.samyookgoo.palgoosam.auction.repository.AuctionRepository;
 import com.samyookgoo.palgoosam.common.response.BaseResponse;
 import com.samyookgoo.palgoosam.notification.dto.NotificationResponseDto;
 import com.samyookgoo.palgoosam.notification.service.NotificationService;
@@ -24,8 +22,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationController {
 
     private final NotificationService notificationService;
-    private final AuctionRepository auctionRepository;
-    private final AuctionImageRepository auctionImageRepository;
 
     @PostMapping("/fcm-token")
     public ResponseEntity<BaseResponse> saveFcmToken(@RequestBody String fcmToken) {

--- a/src/main/java/com/samyookgoo/palgoosam/notification/controller/NotificationController.java
+++ b/src/main/java/com/samyookgoo/palgoosam/notification/controller/NotificationController.java
@@ -51,7 +51,7 @@ public class NotificationController {
 
     @DeleteMapping("/{notificationId}")
     public ResponseEntity<BaseResponse<Void>> deleteNotification(@PathVariable Long notificationId) {
-        notificationService.deleteNorification(notificationId);
+        notificationService.deleteNotification(notificationId);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new BaseResponse<>(200, "알림이 정상적으로 삭제되었습니다.", null));
     }

--- a/src/main/java/com/samyookgoo/palgoosam/notification/fcm/service/FirebaseCloudMessageService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/notification/fcm/service/FirebaseCloudMessageService.java
@@ -7,18 +7,18 @@ import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.MulticastMessage;
 import com.google.firebase.messaging.Notification;
 import com.google.firebase.messaging.TopicManagementResponse;
+import com.samyookgoo.palgoosam.auth.service.AuthService;
 import com.samyookgoo.palgoosam.notification.fcm.domain.UserFcmToken;
 import com.samyookgoo.palgoosam.notification.fcm.dto.FcmMessageDto;
 import com.samyookgoo.palgoosam.notification.fcm.repository.UserFcmTokenRepository;
 import com.samyookgoo.palgoosam.notification.subscription.constant.SubscriptionType;
 import com.samyookgoo.palgoosam.user.domain.User;
-import com.samyookgoo.palgoosam.user.repository.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class FirebaseCloudMessageService {
     private final UserFcmTokenRepository userFcmTokenRepository;
-    private final UserRepository userRepository;
+    private final AuthService authService;
 
     public Boolean validateFcmToken(String token) {
         Message message = Message.builder()
@@ -62,12 +62,12 @@ public class FirebaseCloudMessageService {
     }
 
     public void sendMessage(FcmMessageDto messageDto) {
-        /*
-        User 더미 데이터
-         */
-        User dummyUser = userRepository.findById(1L).orElseThrow(EntityNotFoundException::new);
+        User user = authService.getCurrentUser();
+        if (user == null) {
+            throw new UsernameNotFoundException("유저를 찾을 수 없습니다.");
+        }
 
-        List<UserFcmToken> tokenData = userFcmTokenRepository.findUserFcmTokenListByUserId(dummyUser.getId());
+        List<UserFcmToken> tokenData = userFcmTokenRepository.findUserFcmTokenListByUserId(user.getId());
         MulticastMessage message = MulticastMessage.builder()
                 .setNotification(Notification.builder()
                         .setTitle(messageDto.getAuctionTitle())


### PR DESCRIPTION
### ✅  PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 🎯요약(Summary)
- AuthService의 getCurrentUser 메서드가 에러를 던지지 않고 NULL을 반환하도록 수정 &rarr; 대신 유저의 널체크를 모든 서비스에서 해야 합니다.
- 제가 작성했던 로직들(검색, 검색 기록, 알림)에 대해 현재 로그인 유저를 가져올 수 있도록 수정

### 💻 상세 내용(Describe your changes)


### 📌 관련 이슈번호(Related Issue)
