### PR TITLE
fix: 경매 리스트 반환 시 limit의 디폴트를 12로 수정

### DIFF
--- a/src/main/java/com/samyookgoo/palgoosam/auction/dto/AuctionSearchParam.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/dto/AuctionSearchParam.java
@@ -38,7 +38,7 @@ public class AuctionSearchParam {
 
     @Min(5)
     @NotNull
-    private Integer limit = 10;
+    private Integer limit = 12;
 
     @NotNull
     private String sortBy = "latest";

--- a/src/main/java/com/samyookgoo/palgoosam/auction/dto/AuctionSearchRequestDto.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/dto/AuctionSearchRequestDto.java
@@ -35,7 +35,7 @@ public class AuctionSearchRequestDto {
     private Long detailCategoryId;
 
     private Integer page = 1;
-    private Integer limit = 10;
+    private Integer limit = 12;
 
     public AuctionSearchParam toAuctionSearchParam() {
         Long categoryId = this.checkCategoryId();


### PR DESCRIPTION
### ✅  PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [x] Other… Please describe: 

### 🎯요약(Summary)
- 프론트에서 리스트의 크기가 10보다는 12가 나을 것 같다고 하여 반영했습니다.

### 💻 상세 내용(Describe your changes)


### 📌 관련 이슈번호(Related Issue)
