### PR TITLE
Feat: 알림 구독 로직 추가, 스케줄링을 통해 구독한 사용자에게 알림 보내는 로직 작성

### DIFF
--- a/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionRepository.java
@@ -85,4 +85,20 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
                   AND a.endTime <= :now
             """)
     int updateStatusToCompleted(@Param("now") LocalDateTime now);
+
+    @Query("""
+            SELECT a
+            FROM Auction a
+            WHERE a.startTime BETWEEN :now AND :oneMinuteAgo
+            """)
+    List<Auction> findByStartTimeInOneMinute(@Param("now") LocalDateTime now,
+                                             @Param("oneMinuteAgo") LocalDateTime oneMinuteAgo);
+
+    @Query("""
+            SELECT a
+            FROM Auction a
+            WHERE a.endTime BETWEEN :now AND :oneMinuteAgo AND a.status = 'completed'
+            """)
+    List<Auction> findByEndTimeInOneMinute(@Param("now") LocalDateTime now,
+                                           @Param("oneMinuteAgo") LocalDateTime oneMinuteAgo);
 }

--- a/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
@@ -25,6 +25,8 @@ import com.samyookgoo.palgoosam.auction.repository.CategoryRepository;
 import com.samyookgoo.palgoosam.auth.service.AuthService;
 import com.samyookgoo.palgoosam.bid.domain.Bid;
 import com.samyookgoo.palgoosam.bid.repository.BidRepository;
+import com.samyookgoo.palgoosam.notification.service.NotificationService;
+import com.samyookgoo.palgoosam.notification.subscription.constant.SubscriptionType;
 import com.samyookgoo.palgoosam.payment.domain.Payment;
 import com.samyookgoo.palgoosam.user.domain.Scrap;
 import com.samyookgoo.palgoosam.user.domain.User;
@@ -59,6 +61,8 @@ public class AuctionService {
     private final FileStore fileStore;
     private final BidRepository bidRepository;
     private final AuthService authService;
+    private final NotificationService notificationService;
+
 
     public List<Long> getAuctionIdsByAuctions(List<Auction> auctions) {
         return auctions.stream()
@@ -140,6 +144,7 @@ public class AuctionService {
                             .imageSeq(image.getImageSeq())
                             .build());
         }
+        notificationService.subscribe(auction.getId(), SubscriptionType.SELLER);
 
         return AuctionCreateResponse.builder()
                 .title(auction.getTitle())
@@ -379,6 +384,7 @@ public class AuctionService {
 
         auctionImageRepository.deleteAll(images);
         auctionRepository.delete(auction);
+        notificationService.unsubscribe(auctionId, SubscriptionType.SELLER);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/samyookgoo/palgoosam/auction/service/ScrapService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/service/ScrapService.java
@@ -3,6 +3,8 @@ package com.samyookgoo.palgoosam.auction.service;
 import com.samyookgoo.palgoosam.auction.domain.Auction;
 import com.samyookgoo.palgoosam.auction.repository.AuctionRepository;
 import com.samyookgoo.palgoosam.auth.service.AuthService;
+import com.samyookgoo.palgoosam.notification.service.NotificationService;
+import com.samyookgoo.palgoosam.notification.subscription.constant.SubscriptionType;
 import com.samyookgoo.palgoosam.user.domain.Scrap;
 import com.samyookgoo.palgoosam.user.domain.User;
 import com.samyookgoo.palgoosam.user.repository.ScrapRepository;
@@ -20,6 +22,7 @@ public class ScrapService {
     private final AuctionRepository auctionRepository;
     private final ScrapRepository scrapRepository;
     private final AuthService authService;
+    private final NotificationService notificationService;
 
     @Transactional
     public boolean addScrap(Long auctionId) {
@@ -39,6 +42,7 @@ public class ScrapService {
         scrap.setUser(user);
         scrap.setAuction(auction);
         scrapRepository.save(scrap);
+        notificationService.subscribe(auctionId, SubscriptionType.SCRAPPER);
         return true;
     }
 
@@ -58,6 +62,7 @@ public class ScrapService {
             return false;
         }
         scrapRepository.delete(optionalScrap.get());
+        notificationService.unsubscribe(auctionId, SubscriptionType.SCRAPPER);
         return true;
     }
 

--- a/src/main/java/com/samyookgoo/palgoosam/auction/service/ScrapService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/service/ScrapService.java
@@ -6,7 +6,6 @@ import com.samyookgoo.palgoosam.auth.service.AuthService;
 import com.samyookgoo.palgoosam.user.domain.Scrap;
 import com.samyookgoo.palgoosam.user.domain.User;
 import com.samyookgoo.palgoosam.user.repository.ScrapRepository;
-import com.samyookgoo.palgoosam.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import java.util.Optional;
@@ -18,7 +17,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class ScrapService {
 
-    private final UserRepository userRepository;
     private final AuctionRepository auctionRepository;
     private final ScrapRepository scrapRepository;
     private final AuthService authService;

--- a/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
@@ -8,11 +8,16 @@ import com.samyookgoo.palgoosam.bid.controller.response.BidResponse;
 import com.samyookgoo.palgoosam.bid.domain.Bid;
 import com.samyookgoo.palgoosam.bid.projection.AuctionMaxBid;
 import com.samyookgoo.palgoosam.bid.repository.BidRepository;
+import com.samyookgoo.palgoosam.notification.service.NotificationService;
+import com.samyookgoo.palgoosam.notification.subscription.constant.SubscriptionType;
 import com.samyookgoo.palgoosam.user.domain.User;
 import com.samyookgoo.palgoosam.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -26,6 +31,7 @@ public class BidService {
     private final BidRepository bidRepository;
     private final AuctionRepository auctionRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     public Map<Long, Integer> getAuctionMaxPrices(List<Long> auctionIds) {
         return bidRepository
@@ -104,7 +110,7 @@ public class BidService {
         Bid savedBid = bidRepository.save(bid);
         // TODO: MapStruct, ModelMapper 논의 후 사용 예정
         BidResponse bidResponse = mapToResponse(savedBid);
-
+        notificationService.subscribe(auctionId, SubscriptionType.BIDDER);
         return createBidEventResponse(auctionId, bidResponse, false);
     }
 
@@ -137,7 +143,7 @@ public class BidService {
         updateWinningBid(auctionId);
 
         BidResponse bidResponse = mapToResponse(bid);
-
+        notificationService.unsubscribe(auctionId, SubscriptionType.BIDDER);
         return createBidEventResponse(auctionId, bidResponse, true);
     }
 

--- a/src/main/java/com/samyookgoo/palgoosam/notification/constant/NotificationTemplates.java
+++ b/src/main/java/com/samyookgoo/palgoosam/notification/constant/NotificationTemplates.java
@@ -3,7 +3,7 @@ package com.samyookgoo.palgoosam.notification.constant;
 public class NotificationTemplates {
 
     public static String getAuctionStartingTemplate(String auctionTitle) {
-        return String.format("경매 '%s' 시작 5분 전입니다! 지금 참여하세요.", auctionTitle);
+        return String.format("곧 경매 '%s'가 시작합니다! 지금 참여하세요.", auctionTitle);
     }
 
     public static String getNewBidTemplate(String auctionTitle, int bidAmount) {

--- a/src/main/java/com/samyookgoo/palgoosam/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/samyookgoo/palgoosam/notification/scheduler/NotificationScheduler.java
@@ -1,0 +1,109 @@
+package com.samyookgoo.palgoosam.notification.scheduler;
+
+import com.samyookgoo.palgoosam.auction.domain.Auction;
+import com.samyookgoo.palgoosam.auction.domain.AuctionImage;
+import com.samyookgoo.palgoosam.auction.repository.AuctionImageRepository;
+import com.samyookgoo.palgoosam.auction.repository.AuctionRepository;
+import com.samyookgoo.palgoosam.notification.constant.NotificationTemplates;
+import com.samyookgoo.palgoosam.notification.dto.NotificationRequestDto;
+import com.samyookgoo.palgoosam.notification.service.NotificationService;
+import com.samyookgoo.palgoosam.notification.subscription.constant.SubscriptionType;
+import com.samyookgoo.palgoosam.notification.subscription.domain.AuctionSubscription;
+import com.samyookgoo.palgoosam.notification.subscription.repository.AuctionSubscriptionRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationScheduler {
+    private final NotificationService notificationService;
+    private final AuctionRepository auctionRepository;
+    private final AuctionSubscriptionRepository auctionSubscriptionRepository;
+    private final AuctionImageRepository auctionImageRepository;
+
+    @Scheduled(fixedRate = 60000)
+    @Async
+    public void checkAuctionStart() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime oneMinuteAgo = now.minusMinutes(1);
+        List<Auction> auctionList = auctionRepository.findByStartTimeInOneMinute(now, oneMinuteAgo);
+        auctionList.forEach(auction -> {
+            List<AuctionSubscription> subscriberList = auctionSubscriptionRepository.findAllByAuction(auction);
+            List<Long> scrapperIdList = subscriberList.stream().filter(auctionSubscription ->
+                    auctionSubscription.getType().equals(SubscriptionType.SCRAPPER)
+            ).map(auctionSubscription -> auctionSubscription.getUser().getId()).toList();
+            AuctionImage image = auctionImageRepository.findMainImageByAuctionId(auction.getId()).orElse(null);
+
+            NotificationRequestDto bidderRequestDto = NotificationRequestDto.builder()
+                    .auctionId(auction.getId())
+                    .title(auction.getTitle())
+                    .message(NotificationTemplates.getAuctionStartingTemplate(auction.getTitle()))
+                    .subscriptionType(SubscriptionType.SCRAPPER)
+                    .imageUrl(image != null ? image.getUrl() : null).build();
+            notificationService.sendTopicMessage(bidderRequestDto, scrapperIdList);
+
+            List<Long> sellerIdList = subscriberList.stream().filter(auctionSubscription ->
+                    auctionSubscription.getType().equals(SubscriptionType.SELLER)
+            ).map(auctionSubscription -> auctionSubscription.getUser().getId()).toList();
+            NotificationRequestDto sellerRequestDto = NotificationRequestDto.builder()
+                    .auctionId(auction.getId())
+                    .title(auction.getTitle())
+                    .message(NotificationTemplates.getAuctionStartingTemplate(auction.getTitle()))
+                    .subscriptionType(SubscriptionType.SELLER)
+                    .imageUrl(image != null ? image.getUrl() : null).build();
+            notificationService.sendTopicMessage(sellerRequestDto, sellerIdList);
+        });
+    }
+
+    @Scheduled(fixedRate = 60000)
+    @Async
+    public void checkAuctionCompletion() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime oneMinuteAgo = now.minusMinutes(1);
+        List<Auction> auctionList = auctionRepository.findByEndTimeInOneMinute(now, oneMinuteAgo);
+        auctionList.forEach(auction -> {
+            List<AuctionSubscription> subscriberList = auctionSubscriptionRepository.findAllByAuction(auction);
+            AuctionImage image = auctionImageRepository.findMainImageByAuctionId(auction.getId()).orElse(null);
+
+            List<Long> bidderIdList = subscriberList.stream().filter(auctionSubscription ->
+                    auctionSubscription.getType().equals(SubscriptionType.BIDDER)
+            ).map(auctionSubscription -> auctionSubscription.getUser().getId()).toList();
+            NotificationRequestDto bidderRequestDto = NotificationRequestDto.builder()
+                    .auctionId(auction.getId())
+                    .title(auction.getTitle())
+                    .message(NotificationTemplates.getAuctionEndedTemplate(auction.getTitle()))
+                    .subscriptionType(SubscriptionType.BIDDER)
+                    .imageUrl(image != null ? image.getUrl() : null).build();
+            notificationService.sendTopicMessage(bidderRequestDto, bidderIdList);
+
+            List<Long> sellerList = subscriberList.stream().filter(auctionSubscription ->
+                    auctionSubscription.getType().equals(SubscriptionType.SELLER)
+            ).map(auctionSubscription -> auctionSubscription.getUser().getId()).toList();
+            NotificationRequestDto sellerRequestDto = NotificationRequestDto.builder()
+                    .auctionId(auction.getId())
+                    .title(auction.getTitle())
+                    .message(NotificationTemplates.getAuctionEndedTemplate(auction.getTitle()))
+                    .subscriptionType(SubscriptionType.BIDDER)
+                    .imageUrl(image != null ? image.getUrl() : null).build();
+            notificationService.sendTopicMessage(sellerRequestDto, sellerList);
+
+            List<Long> scrapperList = subscriberList.stream().filter(auctionSubscription ->
+                    auctionSubscription.getType().equals(SubscriptionType.SCRAPPER)
+            ).map(auctionSubscription -> auctionSubscription.getUser().getId()).toList();
+            NotificationRequestDto scrapperRequestDto = NotificationRequestDto.builder()
+                    .auctionId(auction.getId())
+                    .title(auction.getTitle())
+                    .message(NotificationTemplates.getAuctionEndedTemplate(auction.getTitle()))
+                    .subscriptionType(SubscriptionType.SCRAPPER)
+                    .imageUrl(image != null ? image.getUrl() : null).build();
+            notificationService.sendTopicMessage(scrapperRequestDto, scrapperList);
+        });
+    }
+
+}

--- a/src/main/java/com/samyookgoo/palgoosam/notification/subscription/repository/AuctionSubscriptionRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/notification/subscription/repository/AuctionSubscriptionRepository.java
@@ -10,4 +10,6 @@ public interface AuctionSubscriptionRepository extends JpaRepository<AuctionSubs
     List<AuctionSubscription> findAllByUserAndAuction(User user, Auction auction);
 
     List<AuctionSubscription> findAllByUser(User user);
+
+    List<AuctionSubscription> findAllByAuction(Auction auction);
 }


### PR DESCRIPTION
### ✅  PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 🎯요약(Summary)
- 스크랩 할 때, 입찰 할 때, 새로운 경매를 생성할 때 각각 scrapper, bidder, seller의 타입으로 구독을 시킵니다.
- 스크랩 해제할 때, 입찰 취소할 때, 경매를 삭제할 때 각각 scrapper, bidder, seller 타입으로 구독을 취소시킵니다.
- 프론트에서 fcm token을 저장하는 로직이 있어야 합니다. (fcm 토큰이 없으면 에러가 발생할 수 있습니다.)

### 💻 상세 내용(Describe your changes)
- 시작까지 1분 미만인 경매들을 골라서 알림을 보냅니다.
- 종료후 시간이 1분 미만인 경매들을 골라서 알림을 보냅니다.

### 📌 관련 이슈번호(Related Issue)
