### PR TITLE
Feat: 경매 입찰 금액 유효성 검증 및 취소된 입찰 제외한 카운트 로직 적용

### DIFF
--- a/src/main/java/com/samyookgoo/palgoosam/auction/dto/response/RelatedAuctionResponse.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/dto/response/RelatedAuctionResponse.java
@@ -53,7 +53,7 @@ public class RelatedAuctionResponse {
         }
         int scrapCount = scrapRepository.countByAuctionId(auction.getId());
 
-        int bidCount = bidRepository.countByAuctionId(auction.getId());
+        int bidCount = bidRepository.countByAuctionIdAndIsDeletedFalse(auction.getId());
 
         Integer winningPrice = bidRepository.findMaxBidPriceByAuctionId(auction.getId());
 

--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/request/BidRequest.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/request/BidRequest.java
@@ -1,6 +1,7 @@
 package com.samyookgoo.palgoosam.bid.controller.request;
 
 import com.samyookgoo.palgoosam.common.validation.DivisibleBy;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
@@ -9,6 +10,7 @@ import lombok.Data;
 public class BidRequest {
     @NotNull(message = "입찰 금액은 필수입니다.")
     @Min(value = 0, message = "입찰 금액은 0원 이상이어야 합니다.")
+    @Max(value = 1_000_000_000, message = "입찰 금액은 최대 10억까지 가능합니다.")
     @DivisibleBy(value = 100, message = "입찰 금액은 100원 단위여야 합니다.")
     private Integer price;
 }

--- a/src/main/java/com/samyookgoo/palgoosam/bid/repository/BidRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/repository/BidRepository.java
@@ -1,10 +1,9 @@
 package com.samyookgoo.palgoosam.bid.repository;
 
 import com.samyookgoo.palgoosam.bid.domain.Bid;
+import com.samyookgoo.palgoosam.bid.projection.AuctionMaxBid;
 import java.util.List;
 import java.util.Optional;
-
-import com.samyookgoo.palgoosam.bid.projection.AuctionMaxBid;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,12 +11,12 @@ import org.springframework.data.repository.query.Param;
 
 public interface BidRepository extends JpaRepository<Bid, Long> {
     @Query("""
-        SELECT b.auction.id AS auctionId,
-               MAX(b.price)     AS maxPrice
-        FROM Bid b
-        WHERE b.auction.id IN :auctionIds
-        GROUP BY b.auction.id
-    """)
+                SELECT b.auction.id AS auctionId,
+                       MAX(b.price)     AS maxPrice
+                FROM Bid b
+                WHERE b.auction.id IN :auctionIds
+                GROUP BY b.auction.id
+            """)
     List<AuctionMaxBid> findMaxBidPricesByAuctionIds(@Param("auctionIds") List<Long> auctionIds);
 
     List<Bid> findAllByBidder_Id(Long bidderId);
@@ -42,8 +41,8 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
             """, nativeQuery = true)
     List<Bid> findByAuctionIdList(@Param("auctionIdList") List<Long> auctionIdList);
 
-    Integer countByAuctionId(Long auctionId);
+    Integer countByAuctionIdAndIsDeletedFalse(Long auctionId);
 
-    @Query("SELECT COUNT(DISTINCT b.bidder.id) FROM Bid b WHERE b.auction.id = :auctionId")
+    @Query("SELECT COUNT(DISTINCT b.bidder.id) FROM Bid b WHERE b.auction.id = :auctionId AND b.isDeleted = false")
     Integer countDistinctBidderByAuctionId(Long auctionId);
 }

--- a/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
@@ -12,7 +12,10 @@ import com.samyookgoo.palgoosam.user.domain.User;
 import com.samyookgoo.palgoosam.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -156,7 +159,7 @@ public class BidService {
 
     private BidEventResponse createBidEventResponse(Long auctionId, BidResponse bidResponse, boolean isCancelled) {
         Integer currentPrice = bidRepository.findMaxBidPriceByAuctionId(auctionId);
-        int totalBid = bidRepository.countByAuctionId(auctionId);
+        int totalBid = bidRepository.countByAuctionIdAndIsDeletedFalse(auctionId);
         int totalBidder = bidRepository.countDistinctBidderByAuctionId(auctionId);
 
         return BidEventResponse.builder()

--- a/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
@@ -57,11 +57,8 @@ public class BidService {
                 .map(this::mapToResponse)
                 .toList();
 
-        int totalBid = allBids.size();
-        int totalBidder = (int) allBids.stream()
-                .map(b -> b.getBidder().getId())
-                .distinct()
-                .count();
+        int totalBid = bidRepository.countByAuctionIdAndIsDeletedFalse(auctionId);
+        int totalBidder = bidRepository.countDistinctBidderByAuctionId(auctionId);
 
         return BidListResponse.builder()
                 .auctionId(auctionId)


### PR DESCRIPTION
### ✅  PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 🎯요약(Summary)
- 기존 입찰 카운트 쿼리에 삭제된 입찰이 포함되어있었음 -> 포함 안되도록 수정
- 이후 입찰 금액 유효성 검증 추가 

### 💻 상세 내용(Describe your changes)
- 입찰 금액이 10억(1,000,000,000)을 초과하지 않도록 `@Max` 유효성 검증 추가
- 입찰 수 및 입찰자 수 카운트 시 `isDeleted = false` 조건을 적용하여, 취소된 입찰은 집계에서 제외되도록 수정

### 📌 관련 이슈번호(Related Issue)
- #92 
