### PR TITLE
Hotfix: 입찰 취소 횟수 제한 및 판매자 입찰 금지 로직 추가

### DIFF
--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidListResponse.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidListResponse.java
@@ -10,7 +10,7 @@ public class BidListResponse {
     private Long auctionId;
     private Integer totalBid;
     private Integer totalBidder;
-    private BidResponse userBid;
+    private BidResponse recentUserBid;
     private List<BidResponse> bids;
     private List<BidResponse> cancelledBids;
 }

--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidResponse.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidResponse.java
@@ -1,5 +1,7 @@
 package com.samyookgoo.palgoosam.bid.controller.response;
 
+import com.samyookgoo.palgoosam.bid.domain.Bid;
+import java.time.format.DateTimeFormatter;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,4 +13,16 @@ public class BidResponse {
     private Integer bidPrice;
     private String createdAt;
     private String updatedAt;
+
+    public static BidResponse from(Bid bid) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+        return BidResponse.builder()
+                .bidId(bid.getId())
+                .bidderEmail(bid.getBidder().getEmail())
+                .bidPrice(bid.getPrice())
+                .createdAt(bid.getCreatedAt().format(formatter))
+                .updatedAt(bid.getUpdatedAt() != null ? bid.getUpdatedAt().format(formatter) : null)
+                .build();
+    }
 }

--- a/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
@@ -98,6 +98,10 @@ public class BidService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NoSuchElementException("해당 사용자를 찾을 수 없습니다."));
 
+        if (auction.getSeller().getId().equals(user.getId())) {
+            throw new IllegalStateException("판매자는 자신의 경매에 입찰할 수 없습니다.");
+        }
+
         LocalDateTime now = LocalDateTime.now();
         if (now.isBefore(auction.getStartTime()) || now.isAfter(auction.getEndTime())) {
             throw new IllegalStateException("현재는 입찰 가능한 시간이 아닙니다.");

--- a/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
@@ -11,7 +11,6 @@ import com.samyookgoo.palgoosam.bid.repository.BidRepository;
 import com.samyookgoo.palgoosam.user.domain.User;
 import com.samyookgoo.palgoosam.user.repository.UserRepository;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +39,6 @@ public class BidService {
                 ));
     }
 
-
     public BidListResponse getBidsByAuctionId(Long auctionId, User user) {
         if (!auctionRepository.existsById(auctionId)) {
             throw new NoSuchElementException("해당 경매를 찾을 수 없습니다.");
@@ -61,7 +59,7 @@ public class BidService {
         }
 
         for (Bid bid : allBids) {
-            BidResponse response = mapToResponse(bid);
+            BidResponse response = BidResponse.from(bid);
 
             if (Boolean.TRUE.equals(bid.getIsDeleted())) {
                 cancelledBids.add(response);
@@ -98,23 +96,7 @@ public class BidService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NoSuchElementException("해당 사용자를 찾을 수 없습니다."));
 
-        if (auction.getSeller().getId().equals(user.getId())) {
-            throw new IllegalStateException("판매자는 자신의 경매에 입찰할 수 없습니다.");
-        }
-
-        LocalDateTime now = LocalDateTime.now();
-        if (now.isBefore(auction.getStartTime()) || now.isAfter(auction.getEndTime())) {
-            throw new IllegalStateException("현재는 입찰 가능한 시간이 아닙니다.");
-        }
-
-        if (auction.getBasePrice() > price) {
-            throw new IllegalArgumentException("시작가보다 높은 금액을 입력해야 합니다.");
-        }
-
-        Integer highestPrice = bidRepository.findMaxBidPriceByAuctionId(auctionId);
-        if (highestPrice != null && price <= highestPrice) {
-            throw new IllegalArgumentException("현재 최고가보다 높은 금액을 입력해야 합니다.");
-        }
+        validatePlaceBid(auction, user, price);
 
         clearPreviousWinningBid(auctionId);
 
@@ -127,8 +109,7 @@ public class BidService {
                 .build();
 
         Bid savedBid = bidRepository.save(bid);
-        // TODO: MapStruct, ModelMapper 논의 후 사용 예정
-        BidResponse bidResponse = mapToResponse(savedBid);
+        BidResponse bidResponse = BidResponse.from(savedBid);
 
         return createBidEventResponse(auctionId, bidResponse, false);
     }
@@ -138,37 +119,17 @@ public class BidService {
         Auction auction = auctionRepository.findById(auctionId)
                 .orElseThrow(() -> new NoSuchElementException("해당 경매를 찾을 수 없습니다."));
 
-        LocalDateTime now = LocalDateTime.now();
-        if (now.isBefore(auction.getStartTime()) || now.isAfter(auction.getEndTime())) {
-            throw new IllegalStateException("현재는 경매 진행 상태가 아닙니다.");
-        }
-
         Bid bid = bidRepository.findById(bidId)
                 .orElseThrow(() -> new NoSuchElementException("해당 입찰 내역이 존재하지 않습니다."));
 
-        if (!bid.getBidder().getId().equals(currentUser.getId())) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인의 입찰만 취소할 수 있습니다.");
-        }
-
-        if (bid.getIsDeleted() == Boolean.TRUE) {
-            throw new IllegalStateException("이미 취소된 입찰입니다.");
-        }
-
-        if (isExistCancelledBidBefore(auctionId, bid.getBidder().getId())) {
-            throw new IllegalStateException("입찰 취소는 1번만 가능합니다.");
-        }
-
-        LocalDateTime cancellableUntil = bid.getCreatedAt().plusMinutes(1);
-        if (LocalDateTime.now().isAfter(cancellableUntil)) {
-            throw new IllegalStateException("입찰 후 1분 이내에만 취소할 수 있습니다.");
-        }
+        validateCancelBid(auction, bid, currentUser);
 
         bid.setIsWinning(Boolean.FALSE);
         bid.setIsDeleted(Boolean.TRUE);
 
         updateWinningBid(auctionId);
 
-        BidResponse bidResponse = mapToResponse(bid);
+        BidResponse bidResponse = BidResponse.from(bid);
 
         return createBidEventResponse(auctionId, bidResponse, true);
     }
@@ -208,15 +169,47 @@ public class BidService {
         return bidRepository.existsByAuctionIdAndBidderIdAndIsDeletedTrue(auctionId, userId);
     }
 
-    private BidResponse mapToResponse(Bid bid) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private void validatePlaceBid(Auction auction, User user, int price) {
+        if (auction.getSeller().getId().equals(user.getId())) {
+            throw new IllegalStateException("판매자는 자신의 경매에 입찰할 수 없습니다.");
+        }
 
-        return BidResponse.builder()
-                .bidId(bid.getId())
-                .bidderEmail(bid.getBidder().getEmail())
-                .bidPrice(bid.getPrice())
-                .createdAt(bid.getCreatedAt().format(formatter))
-                .updatedAt(bid.getUpdatedAt() != null ? bid.getUpdatedAt().format(formatter) : null)
-                .build();
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isBefore(auction.getStartTime()) || now.isAfter(auction.getEndTime())) {
+            throw new IllegalStateException("현재는 입찰 가능한 시간이 아닙니다.");
+        }
+
+        if (price < auction.getBasePrice()) {
+            throw new IllegalArgumentException("입찰 금액은 시작가 이상이어야 합니다.");
+        }
+
+        Integer highestPrice = bidRepository.findMaxBidPriceByAuctionId(auction.getId());
+        if (highestPrice != null && price <= highestPrice) {
+            throw new IllegalArgumentException("입찰 금액은 현재 최고가보다 높아야 합니다.");
+        }
+    }
+
+    private void validateCancelBid(Auction auction, Bid bid, User currentUser) {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isBefore(auction.getStartTime()) || now.isAfter(auction.getEndTime())) {
+            throw new IllegalStateException("현재는 경매 진행 상태가 아닙니다.");
+        }
+
+        if (!bid.getBidder().getId().equals(currentUser.getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인의 입찰만 취소할 수 있습니다.");
+        }
+
+        if (Boolean.TRUE.equals(bid.getIsDeleted())) {
+            throw new IllegalStateException("이미 취소된 입찰입니다.");
+        }
+
+        if (isExistCancelledBidBefore(auction.getId(), bid.getBidder().getId())) {
+            throw new IllegalStateException("입찰 취소는 1번만 가능합니다.");
+        }
+
+        if (now.isAfter(bid.getCreatedAt().plusMinutes(1))) {
+            throw new IllegalStateException("입찰 후 1분 이내에만 취소할 수 있습니다.");
+        }
     }
 }


### PR DESCRIPTION
### ✅  PR Type

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 🎯요약(Summary)
- 입찰 취소는 경매당 1회로 제한되도록 로직 수정
- 판매자가 자신의 경매에 입찰하지 못하도록 유효성 검증 로직 추가
- 전체적인 관련 코드 리팩토링

### 💻 상세 내용(Describe your changes)
- BidService 내 취소 로직에 '기존 취소 이력 확인' 부분 코드 수정
- 입찰 시, 상품 등록자와 입찰자가 동일한 경우 예외 발생
- 유효성 검증 로직 별도 함수로 분리

### 📌 관련 이슈번호(Related Issue)
- #115 