### PR TITLE
Feat: 입찰 API 응답에 canCancelBid 필드 추가

### DIFF
--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/BidController.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/BidController.java
@@ -8,7 +8,7 @@ import com.samyookgoo.palgoosam.bid.controller.request.BidRequest;
 import com.samyookgoo.palgoosam.bid.controller.response.BaseResponse;
 import com.samyookgoo.palgoosam.bid.controller.response.BidEventResponse;
 import com.samyookgoo.palgoosam.bid.controller.response.BidListResponse;
-import com.samyookgoo.palgoosam.bid.controller.response.BidResponse;
+import com.samyookgoo.palgoosam.bid.controller.response.BidResultResponse;
 import com.samyookgoo.palgoosam.bid.service.BidService;
 import com.samyookgoo.palgoosam.bid.service.SseService;
 import com.samyookgoo.palgoosam.user.domain.User;
@@ -50,7 +50,7 @@ public class BidController {
 
     @PlaceBidApi
     @PostMapping("/{auctionId}/bids")
-    public BaseResponse<BidResponse> placeBid(
+    public BaseResponse<BidResultResponse> placeBid(
             @Parameter(name = "auctionId", description = "입찰할 경매 ID", required = true)
             @PathVariable Long auctionId,
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -63,12 +63,11 @@ public class BidController {
         if (user == null) {
             throw new UsernameNotFoundException("유저를 찾을 수 없습니다.");
         }
-        BidEventResponse response = bidService.placeBid(auctionId, user.getId(), request.getPrice());
-        sseService.broadcastBidUpdate(auctionId, response);
 
-        return BaseResponse.success(response.getBid());
+        BidResultResponse response = bidService.placeBid(auctionId, user.getId(), request.getPrice());
+        return BaseResponse.success(response);
     }
-    
+
     @CancelBidApi
     @CrossOrigin(origins = "http://localhost:3000")
     @PatchMapping("/{auctionId}/bids/{bidId}")

--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidListResponse.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidListResponse.java
@@ -10,6 +10,7 @@ public class BidListResponse {
     private Long auctionId;
     private Integer totalBid;
     private Integer totalBidder;
+    private Boolean canCancelBid;
     private BidResponse recentUserBid;
     private List<BidResponse> bids;
     private List<BidResponse> cancelledBids;

--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidResultResponse.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidResultResponse.java
@@ -1,0 +1,16 @@
+package com.samyookgoo.palgoosam.bid.controller.response;
+
+import lombok.Builder;
+
+@Builder
+public class BidResultResponse {
+    private Boolean canCancelBid;
+    private BidResponse bid;
+
+    public static BidResultResponse from(BidResponse bid, boolean canCancelBid) {
+        return BidResultResponse.builder()
+                .bid(bid)
+                .canCancelBid(canCancelBid)
+                .build();
+    }
+}

--- a/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidResultResponse.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/controller/response/BidResultResponse.java
@@ -1,7 +1,9 @@
 package com.samyookgoo.palgoosam.bid.controller.response;
 
 import lombok.Builder;
+import lombok.Getter;
 
+@Getter
 @Builder
 public class BidResultResponse {
     private Boolean canCancelBid;

--- a/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
@@ -5,6 +5,7 @@ import com.samyookgoo.palgoosam.auction.repository.AuctionRepository;
 import com.samyookgoo.palgoosam.bid.controller.response.BidEventResponse;
 import com.samyookgoo.palgoosam.bid.controller.response.BidListResponse;
 import com.samyookgoo.palgoosam.bid.controller.response.BidResponse;
+import com.samyookgoo.palgoosam.bid.controller.response.BidResultResponse;
 import com.samyookgoo.palgoosam.bid.domain.Bid;
 import com.samyookgoo.palgoosam.bid.projection.AuctionMaxBid;
 import com.samyookgoo.palgoosam.bid.repository.BidRepository;
@@ -28,6 +29,7 @@ public class BidService {
     private final BidRepository bidRepository;
     private final AuctionRepository auctionRepository;
     private final UserRepository userRepository;
+    private final SseService sseService;
 
     public Map<Long, Integer> getAuctionMaxPrices(List<Long> auctionIds) {
         return bidRepository
@@ -89,7 +91,7 @@ public class BidService {
     }
 
     @Transactional
-    public BidEventResponse placeBid(Long auctionId, Long userId, int price) {
+    public BidResultResponse placeBid(Long auctionId, Long userId, int price) {
         Auction auction = auctionRepository.findById(auctionId)
                 .orElseThrow(() -> new NoSuchElementException("해당 경매를 찾을 수 없습니다."));
 
@@ -110,8 +112,12 @@ public class BidService {
 
         Bid savedBid = bidRepository.save(bid);
         BidResponse bidResponse = BidResponse.from(savedBid);
+        boolean canCancelBid = !isExistCancelledBidBefore(auctionId, userId);
 
-        return createBidEventResponse(auctionId, bidResponse, false);
+        BidEventResponse event = createBidEventResponse(auctionId, bidResponse, false);
+        sseService.broadcastBidUpdate(auctionId, event);
+
+        return BidResultResponse.from(bidResponse, canCancelBid);
     }
 
     @Transactional

--- a/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/service/BidService.java
@@ -51,6 +51,7 @@ public class BidService {
         List<BidResponse> activeBids = new ArrayList<>();
         List<BidResponse> cancelledBids = new ArrayList<>();
         BidResponse recentUserBid = null; // 유저의 최근 1분 내 입찰 정보. 비회원이거나 1분 내 입찰 없으면 null
+        boolean canCancelBid = false;
         boolean isExistCancelled = false;
 
         LocalDateTime oneMinuteAgo = LocalDateTime.now().minusMinutes(1);
@@ -73,6 +74,7 @@ public class BidService {
             if (user != null && !isExistCancelled) {
                 if (recentUserBid == null && isRecentBidByUser(bid, user, oneMinuteAgo)) {
                     recentUserBid = response;
+                    canCancelBid = true;
                 }
             }
         }
@@ -84,6 +86,7 @@ public class BidService {
                 .auctionId(auctionId)
                 .totalBid(totalBid)
                 .totalBidder(totalBidder)
+                .canCancelBid(canCancelBid)
                 .recentUserBid(recentUserBid)
                 .bids(activeBids)
                 .cancelledBids(cancelledBids)


### PR DESCRIPTION
### ✅  PR Type

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 🎯요약(Summary)
- 입찰 직후 1분 동안 사용자에게 한 번의 입찰 취소 기회를 제공하는 정책을 반영하기 위해, 입찰 관련 API 응답에 `canCancelBid` 필드를 추가했습니다. 이를 통해 프론트엔드에서 입찰 취소 버튼 노출 여부를 정확히 제어할 수 있습니다.

### 💻 상세 내용(Describe your changes)
- `BidResultResponse`에 `canCancelBid` 필드 추가
- 입찰 내역 조회 시 `recentUserBid`가 존재하면 `canCancelBid`도 함께 반환
- 입찰 취소 가능 여부 로직: 최근 입찰이 1분 이내이며, 이전에 취소한 적이 없는 경우만 true

### 📌 관련 이슈번호(Related Issue)
- #121 