### PR TITLE
Fix: 경매 검색 로직 수정

### DIFF
--- a/src/main/java/com/samyookgoo/palgoosam/auction/domain/AuctionSearchProjection.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/domain/AuctionSearchProjection.java
@@ -1,0 +1,24 @@
+package com.samyookgoo.palgoosam.auction.domain;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuctionSearchProjection {
+    private Long id;
+    private String title;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private String status;
+    private Integer basePrice;
+    private String thumbnailUrl;
+    private Integer currentPrice;
+    private Long bidderCount;
+    private Long scrapCount;
+}

--- a/src/main/java/com/samyookgoo/palgoosam/auction/dto/request/AuctionSearchRequestDto.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/dto/request/AuctionSearchRequestDto.java
@@ -53,7 +53,8 @@ public class AuctionSearchRequestDto {
     public AuctionSearchDto toAuctionSearchDto() {
         Long categoryId = this.checkCategoryId();
         return new AuctionSearchDto(keyword, categoryId, isBrandNew, isLikeNew, isGentlyUsed, isHeavilyUsed,
-                isDamaged, minPrice, maxPrice, isPending, isActive, isCompleted, page, limit, sortBy);
+                isDamaged, minPrice, maxPrice, isPending, isActive, isCompleted, page, limit, sortBy,
+                (this.page - 1) * this.limit);
     }
 
     private Long checkCategoryId() {

--- a/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionRepository.java
@@ -2,7 +2,6 @@ package com.samyookgoo.palgoosam.auction.repository;
 
 import com.samyookgoo.palgoosam.auction.constant.AuctionStatus;
 import com.samyookgoo.palgoosam.auction.domain.Auction;
-import com.samyookgoo.palgoosam.auction.service.dto.AuctionSearchDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -13,52 +12,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface AuctionRepository extends JpaRepository<Auction, Long> {
     List<Auction> findAllBySeller_Id(Long sellerId);
-
-    @Query(value = """
-             SELECT a.*  FROM auction a
-             JOIN user u ON a.seller_id = u.id
-             JOIN category c ON a.category_id = c.id
-             WHERE
-             MATCH(a.title, a.description)
-             AGAINST (:#{#request.keyword} IN NATURAL LANGUAGE MODE) AND
-             -- 카테고리 SQL
-             (:#{#request.categoryId} IS NULL OR a.category_id IN (
-                 WITH RECURSIVE CategoryHierarchy AS (
-                 SELECT id FROM category WHERE id = :#{#request.categoryId}
-                 UNION ALL
-                 SELECT c.id FROM category c
-                 JOIN CategoryHierarchy ch ON c.parent_id = ch.id
-                 )
-                 SELECT id FROM CategoryHierarchy
-             )) AND
-             --
-             (:#{#request.minPrice} IS NULL OR a.base_price >= :#{#request.minPrice}) AND
-             (:#{#request.maxPrice} IS NULL OR a.base_price <= :#{#request.maxPrice}) AND
-                     (
-                         ((:#{#request.isBrandNew} IS NULL OR :#{#request.isBrandNew} = FALSE) AND
-                          (:#{#request.isLikeNew} IS NULL OR :#{#request.isLikeNew} = FALSE) AND
-                          (:#{#request.isGentlyUsed} IS NULL OR :#{#request.isGentlyUsed} = FALSE) AND
-                          (:#{#request.isHeavilyUsed} IS NULL OR :#{#request.isHeavilyUsed} = FALSE) AND
-                          (:#{#request.isDamaged} IS NULL OR :#{#request.isDamaged} = FALSE))
-                         OR
-                         ((:#{#request.isBrandNew} = TRUE AND a.item_condition = 'brand_new') OR
-                          (:#{#request.isLikeNew} = TRUE AND a.item_condition = 'like_new' ) OR
-                          (:#{#request.isGentlyUsed} = TRUE AND a.item_condition = 'gently_used' ) OR
-                          (:#{#request.isHeavilyUsed} = TRUE AND a.item_condition = 'heavily_used' ) OR
-                          (:#{#request.isDamaged} = TRUE AND a.item_condition = 'damaged' ))
-                     ) AND
-                     (
-                         ((:#{#request.isPending} IS NULL OR :#{#request.isPending} = FALSE) AND
-                          (:#{#request.isActive} IS NULL OR :#{#request.isActive} = FALSE) AND
-                          (:#{#request.isCompleted} IS NULL OR :#{#request.isCompleted} = FALSE))
-                         OR
-                         ((:#{#request.isPending} = TRUE AND a.status = 'pending' ) OR
-                          (:#{#request.isActive} = TRUE AND a.status = 'active' ) OR
-                          (:#{#request.isCompleted} = TRUE AND a.status = 'completed' ))
-                     )
-            ORDER BY a.created_at DESC
-            """, nativeQuery = true)
-    List<Auction> findAllWithDetails(@Param("request") AuctionSearchDto auctionSearchDto);
 
     Optional<Auction> findById(Long id);
 

--- a/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionSearchRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionSearchRepository.java
@@ -1,0 +1,187 @@
+package com.samyookgoo.palgoosam.auction.repository;
+
+import com.samyookgoo.palgoosam.auction.constant.SortType;
+import com.samyookgoo.palgoosam.auction.domain.AuctionSearchProjection;
+import com.samyookgoo.palgoosam.auction.service.dto.AuctionSearchDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AuctionSearchRepository {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    private static final String SEARCH_AUCTIONLIST_QUERY = """
+            SELECT a.id, a.title, a.start_time, a.end_time, a.status, a.base_price, 
+                   COALESCE(i.url, 'test') as thumbnail_url,
+                   COALESCE(MAX(b.price), a.base_price) as current_price, 
+                   COUNT(DISTINCT(b.bidder_id)) as bidder_count,
+                   COUNT(DISTINCT(s.id)) as scrap_count
+            FROM auction a
+            LEFT JOIN bid b ON a.id = b.auction_id AND b.is_deleted = false
+            LEFT JOIN scrap s ON a.id = s.auction_id
+            LEFT JOIN auction_image i ON a.id = i.auction_id
+            JOIN category c ON a.category_id = c.id
+            WHERE
+            MATCH(a.title, a.description) AGAINST (:keyword IN NATURAL LANGUAGE MODE) AND
+            (:categoryId IS NULL OR a.category_id IN (
+                WITH RECURSIVE CategoryHierarchy AS (
+                    SELECT id FROM category WHERE id = :categoryId
+                    UNION ALL
+                    SELECT c.id FROM category c
+                    JOIN CategoryHierarchy ch ON c.parent_id = ch.id
+                )
+                SELECT id FROM CategoryHierarchy
+            )) AND
+            (:maxPrice IS NULL OR a.base_price <= :maxPrice) AND
+            (
+                ((:isBrandNew IS NULL OR :isBrandNew = FALSE) AND
+                 (:isLikeNew IS NULL OR :isLikeNew = FALSE) AND
+                 (:isGentlyUsed IS NULL OR :isGentlyUsed = FALSE) AND
+                 (:isHeavilyUsed IS NULL OR :isHeavilyUsed = FALSE) AND
+                 (:isDamaged IS NULL OR :isDamaged = FALSE))
+                OR
+                ((:isBrandNew = TRUE AND a.item_condition = 'brand_new') OR
+                 (:isLikeNew = TRUE AND a.item_condition = 'like_new') OR
+                 (:isGentlyUsed = TRUE AND a.item_condition = 'gently_used') OR
+                 (:isHeavilyUsed = TRUE AND a.item_condition = 'heavily_used') OR
+                 (:isDamaged = TRUE AND a.item_condition = 'damaged'))
+            ) AND
+            (
+                ((:isPending IS NULL OR :isPending = FALSE) AND
+                 (:isActive IS NULL OR :isActive = FALSE) AND
+                 (:isCompleted IS NULL OR :isCompleted = FALSE))
+                OR
+                ((:isPending = TRUE AND a.status = 'pending') OR
+                 (:isActive = TRUE AND a.status = 'active') OR
+                 (:isCompleted = TRUE AND a.status = 'completed'))
+            )
+            GROUP BY a.id, a.title, a.start_time, a.end_time, a.status, a.base_price, a.created_at, i.url
+            HAVING
+                (:minPrice IS NULL OR COALESCE(MAX(b.price), a.base_price) >= :minPrice) AND
+                (:maxPrice IS NULL OR COALESCE(MAX(b.price), a.base_price) <= :maxPrice)
+            """;
+
+    private final RowMapper<AuctionSearchProjection> rowMapper = (rs, rowNum) ->
+            AuctionSearchProjection.builder()
+                    .id(rs.getLong("id"))
+                    .title(rs.getString("title"))
+                    .startTime(rs.getTimestamp("start_time").toLocalDateTime())
+                    .endTime(rs.getTimestamp("end_time").toLocalDateTime())
+                    .status(rs.getString("status"))
+                    .basePrice(rs.getInt("base_price"))
+                    .thumbnailUrl(rs.getString("thumbnail_url"))
+                    .currentPrice(rs.getInt("current_price"))
+                    .bidderCount(rs.getLong("bidder_count"))
+                    .scrapCount(rs.getLong("scrap_count"))
+                    .build();
+
+    public List<AuctionSearchProjection> search(AuctionSearchDto request) {
+        // 동적 ORDER BY 생성
+        String orderBy = buildOrderByClause(request.getSortBy());
+
+        String fullQuery = SEARCH_AUCTIONLIST_QUERY + orderBy + " LIMIT :limit OFFSET :offset";
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("keyword", request.getKeyword())
+                .addValue("categoryId", request.getCategoryId())
+                .addValue("maxPrice", request.getMaxPrice())
+                .addValue("minPrice", request.getMinPrice())
+                // 상품 상태 필터
+                .addValue("isBrandNew", request.getIsBrandNew())
+                .addValue("isLikeNew", request.getIsLikeNew())
+                .addValue("isGentlyUsed", request.getIsGentlyUsed())
+                .addValue("isHeavilyUsed", request.getIsHeavilyUsed())
+                .addValue("isDamaged", request.getIsDamaged())
+                // 경매 상태 필터
+                .addValue("isPending", request.getIsPending())
+                .addValue("isActive", request.getIsActive())
+                .addValue("isCompleted", request.getIsCompleted())
+                // 페이지네이션
+                .addValue("limit", request.getLimit())
+                .addValue("offset", request.getOffset());
+
+        return jdbcTemplate.query(fullQuery, params, rowMapper);
+    }
+
+    private String buildOrderByClause(String sortBy) {
+        StringBuilder orderBy = new StringBuilder(" ORDER BY ");
+        if (String.valueOf(SortType.price_asc).equals(sortBy)) {
+            orderBy.append("current_price ASC");
+        } else if (String.valueOf(SortType.price_desc).equals(sortBy)) {
+            orderBy.append("current_price DESC");
+        } else if (String.valueOf(SortType.scrap_count_desc).equals(sortBy)) {
+            orderBy.append("scrap_count DESC");
+        } else if (String.valueOf(SortType.bidder_count_desc).equals(sortBy)) {
+            orderBy.append("bidder_count DESC");
+        } else {
+            orderBy.append("a.created_at DESC");
+        }
+
+        return orderBy.toString();
+    }
+
+    public Long countAuctionsInList(AuctionSearchDto request) {
+        String countQuery = """
+                SELECT COUNT(DISTINCT a.id)
+                FROM auction a
+                LEFT JOIN bid b ON a.id = b.auction_id AND b.is_deleted = false
+                LEFT JOIN scrap s ON a.id = s.auction_id
+                LEFT JOIN auction_image i ON a.id = i.auction_id
+                JOIN category c ON a.category_id = c.id
+                WHERE
+                MATCH(a.title, a.description) AGAINST (:keyword IN NATURAL LANGUAGE MODE) AND
+                (:categoryId IS NULL OR a.category_id IN (
+                    WITH RECURSIVE CategoryHierarchy AS (
+                        SELECT id FROM category WHERE id = :categoryId
+                        UNION ALL
+                        SELECT c.id FROM category c
+                        JOIN CategoryHierarchy ch ON c.parent_id = ch.id
+                    )
+                    SELECT id FROM CategoryHierarchy
+                )) AND
+                (:maxPrice IS NULL OR a.base_price <= :maxPrice) AND
+                (
+                    ((:isBrandNew IS NULL OR :isBrandNew = FALSE) AND
+                     (:isLikeNew IS NULL OR :isLikeNew = FALSE) AND
+                     (:isGentlyUsed IS NULL OR :isGentlyUsed = FALSE) AND
+                     (:isHeavilyUsed IS NULL OR :isHeavilyUsed = FALSE) AND
+                     (:isDamaged IS NULL OR :isDamaged = FALSE))
+                    OR
+                    ((:isBrandNew = TRUE AND a.item_condition = 'brand_new') OR
+                     (:isLikeNew = TRUE AND a.item_condition = 'like_new') OR
+                     (:isGentlyUsed = TRUE AND a.item_condition = 'gently_used') OR
+                     (:isHeavilyUsed = TRUE AND a.item_condition = 'heavily_used') OR
+                     (:isDamaged = TRUE AND a.item_condition = 'damaged'))
+                ) AND
+                (
+                    ((:isPending IS NULL OR :isPending = FALSE) AND
+                     (:isActive IS NULL OR :isActive = FALSE) AND
+                     (:isCompleted IS NULL OR :isCompleted = FALSE))
+                    OR
+                    ((:isPending = TRUE AND a.status = 'pending') OR
+                     (:isActive = TRUE AND a.status = 'active') OR
+                     (:isCompleted = TRUE AND a.status = 'completed'))
+                )
+                """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("keyword", request.getKeyword())
+                .addValue("categoryId", request.getCategoryId())
+                .addValue("maxPrice", request.getMaxPrice())
+                .addValue("isBrandNew", request.getIsBrandNew())
+                .addValue("isLikeNew", request.getIsLikeNew())
+                .addValue("isGentlyUsed", request.getIsGentlyUsed())
+                .addValue("isHeavilyUsed", request.getIsHeavilyUsed())
+                .addValue("isDamaged", request.getIsDamaged())
+                .addValue("isPending", request.getIsPending())
+                .addValue("isActive", request.getIsActive())
+                .addValue("isCompleted", request.getIsCompleted());
+
+        return jdbcTemplate.queryForObject(countQuery, params, Long.class);
+    }
+}

--- a/src/main/java/com/samyookgoo/palgoosam/auction/service/dto/AuctionSearchDto.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/service/dto/AuctionSearchDto.java
@@ -42,4 +42,6 @@ public class AuctionSearchDto {
 
     @NotNull
     private String sortBy = "latest";
+
+    private Integer offset;
 }


### PR DESCRIPTION
### ✅  PR Type
- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [x] Other… Please describe: 로직 수정

### 🎯요약(Summary)
- 검색 로직 수정
- JDBC 탬플릿 사용

### 💻 상세 내용(Describe your changes)
기존에는 DB에서 여러 데이터를 모은 뒤 애플리케이션 레벨에서 데이터를 합치고 응답했습니다.
위 과정에서 DB 요청 및 트랜잭션 처리가 여러 번 발생하고, 데이터 정합성 문제가 발생할 수 있습니다. 
(다른 트랜잭션에 의한 더티 리드 등)
그래서 소위 말하는 한방쿼리를 통해 데이터를 한 번에 가져올 수 있도록 수정했습니다.

---

JDBC 탬플릿을 사용한 이유는 다음과 같습니다.
- JPA는 애초에 논외의 대상, JPA로 구현이 불가능해서 네이티브 쿼리로 작성했음.
- JPQL도 마찬가지로 작성하기 힘들어서 네이티브 쿼리로 작성했음. MySQL 네이티브 문법도 있어서 JPQL에서 지원 안하는 부분도 있음.
- Querydsl이나 JooQ 같은 쿼리 빌더 클래스는 새로운 문법을 익혀야 함과 더불어 재귀 설정도 좀 복잡하게 느껴졌음. 이미 작성되었고 동작이 잘 되는 쿼리가 있는데 굳이? 라는 생각이 들었음.
- 만약 시간이 많고 고도화를 할 수 있다면 JooQ를 사용했을 것 같음.(유지보수성, 가독성면에서 팀원들이 이해하기 더 쉬워질 것 같아서)
---
동작 화면
<img width="875" alt="image" src="https://github.com/user-attachments/assets/78eb80f2-d0c1-437f-9ab2-5ad4a574d09e" />

<img width="870" alt="image" src="https://github.com/user-attachments/assets/dc2072db-2b8f-453d-89d0-b62be50d8dc6" />
