### PR TITLE
Feat 실시간 랭킹 경매 중인 상품 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/samyookgoo/palgoosam/auction/controller/HomeController.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/controller/HomeController.java
@@ -1,5 +1,6 @@
 package com.samyookgoo.palgoosam.auction.controller;
 
+import com.samyookgoo.palgoosam.auction.dto.home.ActiveRankingResponse;
 import com.samyookgoo.palgoosam.auction.dto.home.DashboardResponse;
 import com.samyookgoo.palgoosam.auction.dto.home.RecentAuctionResponse;
 import com.samyookgoo.palgoosam.auction.dto.home.TopBidResponse;
@@ -33,13 +34,19 @@ public class HomeController {
 
     @GetMapping("/upcoming")
     public ResponseEntity<BaseResponse<List<UpcomingAuctionResponse>>> getUpcomingAuctions() {
-        List<UpcomingAuctionResponse> upcomingAuctions = homeService.getUpcomingAuctions();
-        return ResponseEntity.ok(BaseResponse.success("임박한 경매 상품 목록 조회 성공", upcomingAuctions));
+        List<UpcomingAuctionResponse> responses = homeService.getUpcomingAuctions();
+        return ResponseEntity.ok(BaseResponse.success("임박한 경매 상품 목록 조회 성공", responses));
     }
-  
+
     @GetMapping("/topBid")
     public ResponseEntity<BaseResponse<List<TopBidResponse>>> getTopBid() {
         List<TopBidResponse> responses = homeService.getTopBid();
         return ResponseEntity.ok(BaseResponse.success("이번주 최고 낙찰가 top 5 조회 성공", responses));
+    }
+
+    @GetMapping("/ranking/active")
+    public ResponseEntity<BaseResponse<List<ActiveRankingResponse>>> getActiveRanking() {
+        List<ActiveRankingResponse> responses = homeService.getActiveRanking();
+        return ResponseEntity.ok(BaseResponse.success("경매중 실시간 랭킹 조회 성공", responses));
     }
 }

--- a/src/main/java/com/samyookgoo/palgoosam/auction/dto/home/ActiveRankingResponse.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/dto/home/ActiveRankingResponse.java
@@ -1,0 +1,16 @@
+package com.samyookgoo.palgoosam.auction.dto.home;
+
+import com.samyookgoo.palgoosam.auction.constant.ItemCondition;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ActiveRankingResponse {
+    private Long auctionId;
+    private String title;
+    private String description;
+    private ItemCondition itemCondition;
+    private String thumbnailUrl;
+    private Integer bidCount;
+}

--- a/src/main/java/com/samyookgoo/palgoosam/auction/projection/ActiveRanking.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/projection/ActiveRanking.java
@@ -1,0 +1,15 @@
+package com.samyookgoo.palgoosam.auction.projection;
+
+import com.samyookgoo.palgoosam.auction.constant.ItemCondition;
+
+public interface ActiveRanking {
+    Long getAuctionId();
+
+    String getTitle();
+
+    String getDescription();
+
+    ItemCondition getItemCondition();
+
+    String getThumbnailUrl();
+}

--- a/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionRepository.java
@@ -2,10 +2,13 @@ package com.samyookgoo.palgoosam.auction.repository;
 
 import com.samyookgoo.palgoosam.auction.constant.AuctionStatus;
 import com.samyookgoo.palgoosam.auction.domain.Auction;
+import com.samyookgoo.palgoosam.auction.projection.ActiveRanking;
+import com.samyookgoo.palgoosam.auction.projection.AuctionBidCount;
 import com.samyookgoo.palgoosam.auction.service.dto.AuctionSearchDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -93,4 +96,23 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
     List<Auction> findTop3ByStatusAndStartTimeAfterOrderByStartTimeAsc(AuctionStatus status, LocalDateTime now);
 
     List<Auction> findTop6ByStatusInOrderByCreatedAtDesc(List<AuctionStatus> statuses);
+
+    @Query("""
+            SELECT a.id AS auctionId, a.title AS title, a.description AS description,
+                   a.itemCondition AS itemCondition, img.url AS thumbnailUrl
+            FROM Auction a
+            JOIN AuctionImage img ON img.auction.id = a.id AND img.imageSeq = 0
+            WHERE a.id IN :auctionIds
+            """)
+    List<ActiveRanking> findActiveRankingByIds(@Param("auctionIds") List<Long> auctionIds);
+
+    @Query("""
+            SELECT a.id AS auctionId, COUNT(b.id) AS bidCount
+            FROM Auction a
+            LEFT JOIN Bid b ON b.auction.id = a.id
+            WHERE a.status = 'ACTIVE'
+            GROUP BY a.id
+            ORDER BY COUNT(b.id) DESC, a.id ASC
+            """)
+    List<AuctionBidCount> findTop8AuctionBidCounts(Pageable pageable);
 }


### PR DESCRIPTION
### ✅  PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 🎯요약(Summary)
실시간 랭킹의 경매 중인 상품 목록 조회 API 구현 

### 💻 상세 내용(Describe your changes)
입찰수 순으로 정렬되고 입찰수가 동일하거나 입찰이 없으면(입찰수가 0) auctionId가 낮은 순으로 정렬
반환 데이터 : 대표이미지, 상품 제목, 상품 상세내용, 상품 상태, 입찰수
![image](https://github.com/user-attachments/assets/3a795f21-d4b0-4705-9c54-103037503f7d)


### 📌 관련 이슈번호(Related Issue)
close #130 