### PR TITLE
Feat: 중분류 카테고리별 베스트 상품 top 3 API 구현

### DIFF
--- a/src/main/java/com/samyookgoo/palgoosam/auction/controller/HomeController.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/controller/HomeController.java
@@ -4,6 +4,7 @@ import com.samyookgoo.palgoosam.auction.dto.home.ActiveRankingResponse;
 import com.samyookgoo.palgoosam.auction.dto.home.DashboardResponse;
 import com.samyookgoo.palgoosam.auction.dto.home.PendingRankingResponse;
 import com.samyookgoo.palgoosam.auction.dto.home.RecentAuctionResponse;
+import com.samyookgoo.palgoosam.auction.dto.home.SubCategoryBestItemResponse;
 import com.samyookgoo.palgoosam.auction.dto.home.TopBidResponse;
 import com.samyookgoo.palgoosam.auction.dto.home.UpcomingAuctionResponse;
 import com.samyookgoo.palgoosam.auction.service.HomeService;
@@ -55,5 +56,11 @@ public class HomeController {
     public ResponseEntity<BaseResponse<List<PendingRankingResponse>>> getPendingRanking() {
         List<PendingRankingResponse> responses = homeService.getPendingRanking();
         return ResponseEntity.ok(BaseResponse.success("경매 예정 실시간 랭킹 조회 성공", responses));
+    }
+
+    @GetMapping("/best-sub-item")
+    public ResponseEntity<BaseResponse<List<SubCategoryBestItemResponse>>> getBestItem() {
+        List<SubCategoryBestItemResponse> responses = homeService.getSubCategoryBestItem();
+        return ResponseEntity.ok(BaseResponse.success("중분류 카테고리별 베스트 상품 조회 성공", responses));
     }
 }

--- a/src/main/java/com/samyookgoo/palgoosam/auction/dto/home/BestItemResponse.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/dto/home/BestItemResponse.java
@@ -1,0 +1,19 @@
+package com.samyookgoo.palgoosam.auction.dto.home;
+
+import com.samyookgoo.palgoosam.auction.constant.AuctionStatus;
+import com.samyookgoo.palgoosam.auction.constant.ItemCondition;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BestItemResponse {
+    private Long auctionId;
+    private String title;
+    private AuctionStatus status;
+    private ItemCondition itemCondition;
+    private String thumbnailUrl;
+    private Boolean isAuctionImminent;  // 경매 임박 여부
+    private Integer scrapCount;
+    private Integer rankNum;
+}

--- a/src/main/java/com/samyookgoo/palgoosam/auction/dto/home/SubCategoryBestItemResponse.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/dto/home/SubCategoryBestItemResponse.java
@@ -1,0 +1,13 @@
+package com.samyookgoo.palgoosam.auction.dto.home;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SubCategoryBestItemResponse {
+    private Long subCategoryId;
+    private String subCategoryName;
+    private List<BestItemResponse> items;
+}

--- a/src/main/java/com/samyookgoo/palgoosam/auction/projection/SubCategoryBestItem.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/projection/SubCategoryBestItem.java
@@ -1,0 +1,19 @@
+package com.samyookgoo.palgoosam.auction.projection;
+
+import com.samyookgoo.palgoosam.auction.constant.AuctionStatus;
+import com.samyookgoo.palgoosam.auction.constant.ItemCondition;
+import java.time.LocalDateTime;
+
+public interface SubCategoryBestItem {
+    Long getAuctionId();
+
+    String getTitle();
+
+    AuctionStatus getStatus();
+
+    ItemCondition getItemCondition();
+
+    String getThumbnailUrl();
+
+    LocalDateTime getStartTime();
+}

--- a/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionRepository.java
@@ -5,7 +5,7 @@ import com.samyookgoo.palgoosam.auction.domain.Auction;
 import com.samyookgoo.palgoosam.auction.projection.AuctionBidCount;
 import com.samyookgoo.palgoosam.auction.projection.AuctionScrapCount;
 import com.samyookgoo.palgoosam.auction.projection.RankingAuction;
-import com.samyookgoo.palgoosam.auction.service.dto.AuctionSearchDto;
+import com.samyookgoo.palgoosam.auction.projection.SubCategoryBestItem;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -80,4 +80,17 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             ORDER BY COUNT(s.id) DESC, a.id ASC
             """)
     List<AuctionScrapCount> findTop8AuctionScrapCounts(Pageable pageable);
+
+    @Query("""
+                SELECT a.id AS auctionId, a.title AS title, a.status AS status, a.itemCondition AS itemCondition,
+                       img.url AS thumbnailUrl, a.startTime AS startTime
+                FROM Auction a
+                JOIN a.category c
+                JOIN c.parent mid
+                LEFT JOIN AuctionImage img ON img.auction.id = a.id AND img.imageSeq = 0
+                WHERE mid.id = :subCategoryId AND a.status IN ('pending', 'active')
+                ORDER BY (SELECT COUNT(s.id) FROM Scrap s WHERE s.auction.id = a.id) DESC, a.id ASC
+            """)
+    List<SubCategoryBestItem> findTop3BySubCategoryId(@Param("subCategoryId") Long subCategoryId, Pageable pageable);
+
 }

--- a/src/main/java/com/samyookgoo/palgoosam/auction/repository/CategoryRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/repository/CategoryRepository.java
@@ -9,4 +9,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     @Query("SELECT c FROM Category c LEFT JOIN FETCH c.children LEFT JOIN FETCH c.parent")
     List<Category> findAllWithChildrenAndParent();
+
+    List<Category> findByParentIsNotNullAndChildrenIsNotEmpty();
 }

--- a/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
@@ -565,7 +565,7 @@ public class AuctionService {
                         .bidderCount(auction.getBidderCount())
                         .currentPrice(auction.getCurrentPrice())
                         .scrapCount(auction.getScrapCount())
-                        .isScrapped(user != null && scrapRepository.existsByUserIdAndAuctionId(user.getId(),
+                        .isScraped(user != null && scrapRepository.existsByUserIdAndAuctionId(user.getId(),
                                 auction.getId()))
                         .build()
         ).toList();

--- a/src/main/java/com/samyookgoo/palgoosam/auction/service/HomeService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/service/HomeService.java
@@ -3,18 +3,23 @@ package com.samyookgoo.palgoosam.auction.service;
 import com.samyookgoo.palgoosam.auction.constant.AuctionStatus;
 import com.samyookgoo.palgoosam.auction.domain.Auction;
 import com.samyookgoo.palgoosam.auction.domain.AuctionImage;
+import com.samyookgoo.palgoosam.auction.domain.Category;
 import com.samyookgoo.palgoosam.auction.dto.home.ActiveRankingResponse;
+import com.samyookgoo.palgoosam.auction.dto.home.BestItemResponse;
 import com.samyookgoo.palgoosam.auction.dto.home.DashboardResponse;
 import com.samyookgoo.palgoosam.auction.dto.home.PendingRankingResponse;
 import com.samyookgoo.palgoosam.auction.dto.home.RecentAuctionResponse;
+import com.samyookgoo.palgoosam.auction.dto.home.SubCategoryBestItemResponse;
 import com.samyookgoo.palgoosam.auction.dto.home.TopBidResponse;
 import com.samyookgoo.palgoosam.auction.dto.home.UpcomingAuctionResponse;
 import com.samyookgoo.palgoosam.auction.projection.AuctionBidCount;
 import com.samyookgoo.palgoosam.auction.projection.AuctionScrapCount;
 import com.samyookgoo.palgoosam.auction.projection.RankingAuction;
+import com.samyookgoo.palgoosam.auction.projection.SubCategoryBestItem;
 import com.samyookgoo.palgoosam.auction.projection.TopWinningBid;
 import com.samyookgoo.palgoosam.auction.repository.AuctionImageRepository;
 import com.samyookgoo.palgoosam.auction.repository.AuctionRepository;
+import com.samyookgoo.palgoosam.auction.repository.CategoryRepository;
 import com.samyookgoo.palgoosam.auth.service.AuthService;
 import com.samyookgoo.palgoosam.bid.repository.BidRepository;
 import com.samyookgoo.palgoosam.user.domain.User;
@@ -46,6 +51,7 @@ public class HomeService {
     private final ScrapRepository scrapRepository;
     private final AuthService authService;
     private final BidRepository bidRepository;
+    private final CategoryRepository categoryRepository;
 
     @Transactional(readOnly = true)
     public DashboardResponse getDashboard() {
@@ -201,6 +207,48 @@ public class HomeService {
                             .build();
                 })
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<SubCategoryBestItemResponse> getSubCategoryBestItem() {
+        List<Category> subCategoryList = categoryRepository.findByParentIsNotNullAndChildrenIsNotEmpty();
+
+        return subCategoryList.stream()
+                .map(sub -> {
+                    List<SubCategoryBestItem> itemProjections = auctionRepository.findTop3BySubCategoryId(sub.getId(),
+                            PageRequest.of(0, 3));
+                    List<AuctionScrapCount> scrapCounts = scrapRepository.countGroupedByAuctionIds(
+                            itemProjections.stream().map(SubCategoryBestItem::getAuctionId).toList()
+                    );
+                    Map<Long, Integer> scrapMap = scrapCounts.stream()
+                            .collect(Collectors.toMap(AuctionScrapCount::getAuctionId,
+                                    AuctionScrapCount::getScrapCount));
+
+                    AtomicInteger rank = new AtomicInteger(1);
+                    List<BestItemResponse> items = itemProjections.stream()
+                            .map(p -> BestItemResponse.builder()
+                                    .auctionId(p.getAuctionId())
+                                    .title(p.getTitle())
+                                    .status(p.getStatus())
+                                    .itemCondition(p.getItemCondition())
+                                    .thumbnailUrl(p.getThumbnailUrl())
+                                    .scrapCount(scrapMap.getOrDefault(p.getAuctionId(), 0))
+                                    .isAuctionImminent(isAuctionImminent(p.getStartTime()))
+                                    .rankNum(rank.getAndIncrement())
+                                    .build())
+                            .toList();
+
+                    return SubCategoryBestItemResponse.builder()
+                            .subCategoryId(sub.getId())
+                            .subCategoryName(sub.getName())
+                            .items(items)
+                            .build();
+                }).toList();
+    }
+
+    private boolean isAuctionImminent(LocalDateTime startTime) {
+        LocalDateTime now = LocalDateTime.now();
+        return startTime.isAfter(now) && Duration.between(now, startTime).toHours() <= 1;
     }
 
     private List<Auction> getRecentAuctionStatus() {

--- a/src/main/java/com/samyookgoo/palgoosam/user/repository/ScrapRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/user/repository/ScrapRepository.java
@@ -32,8 +32,8 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 
     @Query("""
             SELECT s.auction.id AS auctionId, COUNT(s) AS scrapCount
-            FROM Scrap s 
-            WHERE s.auction.id IN :auctionIds 
+            FROM Scrap s
+            WHERE s.auction.id IN :auctionIds
             GROUP BY s.auction.id
             """)
     List<AuctionScrapCount> countGroupedByAuctionIds(List<Long> auctionIds);


### PR DESCRIPTION
### :white_check_mark:  PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### :dart:요약(Summary)
중분류 카테고리별 베스트 상품 목록 조회 API 구현

### :computer: 상세 내용(Describe your changes)
- 중분류 카테고리별 베스트 상품 3개씩 조회
- 경매 예정, 경매 중인 상품 둘 다 조회
- 스크랩 수를 기준으로 정렬 (스크랩 수가 동일하거나 스크랩이 없을 시 (스크랩 수가 0) auctionId가 낮은 순으로 정렬)
- 경매 시작까지 1시간 이내로 남았으면 isAuctionImminent == true
- 반환 데이터 : 대표이미지, 제목, 경매 상태, 상품 상태, 랭킹번호, 스크랩 수, isAuctionImminent 
![image](https://github.com/user-attachments/assets/53c8a9e7-b519-4262-8b0d-31d965d96476)
![image](https://github.com/user-attachments/assets/0a3805b7-f0d2-48df-9e5e-2a716985739a)


### :pushpin: 관련 이슈번호(Related Issue)
close #145 