### PR TITLE
Hotfix: OAuth2로그아웃 쿠키 cross-domain 처리 수정

### DIFF
--- a/src/main/java/com/samyookgoo/palgoosam/auth/controller/AuthController.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auth/controller/AuthController.java
@@ -106,10 +106,12 @@ public class AuthController {
         // 쿠키 삭제
         ResponseCookie deleteAccess = ResponseCookie.from("accessToken", "")
                 .httpOnly(true).secure(true).path("/")
+                .domain("palgoosam.store")
                 .maxAge(0).sameSite("Lax").build();
 
         ResponseCookie deleteRefresh = ResponseCookie.from("refreshToken", "")
                 .httpOnly(true).secure(true).path("/auth/refresh")
+                .domain("palgoosam.store")
                 .maxAge(0).sameSite("Lax").build();
 
         res.addHeader(HttpHeaders.SET_COOKIE, deleteAccess.toString());

--- a/src/main/java/com/samyookgoo/palgoosam/auth/controller/AuthController.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auth/controller/AuthController.java
@@ -107,12 +107,12 @@ public class AuthController {
         ResponseCookie deleteAccess = ResponseCookie.from("accessToken", "")
                 .httpOnly(true).secure(true).path("/")
                 .domain("palgoosam.store")
-                .maxAge(0).sameSite("Lax").build();
+                .maxAge(0).sameSite("None").build();
 
         ResponseCookie deleteRefresh = ResponseCookie.from("refreshToken", "")
                 .httpOnly(true).secure(true).path("/auth/refresh")
                 .domain("palgoosam.store")
-                .maxAge(0).sameSite("Lax").build();
+                .maxAge(0).sameSite("None").build();
 
         res.addHeader(HttpHeaders.SET_COOKIE, deleteAccess.toString());
         res.addHeader(HttpHeaders.SET_COOKIE, deleteRefresh.toString());


### PR DESCRIPTION
### ✅  PR Type
<!— Please check the one that applies to this PR using "x". —>

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 🎯요약(Summary)
- 로그아웃 시 accessToken / refreshToken 쿠키 삭제 시 `.domain("palgoosam.store")` 적용
  - 기존에는 domain 없이 삭제 시도 → www.palgoosam.store 에 쿠키가 남아서 로그아웃 불가 문제 발생
  - 동일한 domain 설정으로 정상 삭제 처리하도록 수정
- SameSite 설정도 로그인/로그아웃 시 모두 `None` 으로 통일하여 cross-site 요청에서도 쿠키 정상 삭제 처리

### 💻 상세 내용(Describe your changes)


### 📌 관련 이슈번호(Related Issue)
