### PR TITLE
Feat: 경매 상태 전환 스케줄링 고도화

### DIFF
--- a/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionRepository.java
@@ -30,24 +30,6 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
     List<Auction> findByParentCategoryIdAndStatus(@Param("parentId") Long parentId,
                                                   @Param("status") AuctionStatus status);
 
-    @Modifying
-    @Query("""
-                UPDATE Auction a
-                SET a.status = 'active'
-                WHERE a.status = 'pending'
-                  AND a.startTime <= :now
-            """)
-    int updateStatusToActive(@Param("now") LocalDateTime now);
-
-    @Modifying
-    @Query("""
-                UPDATE Auction a
-                SET a.status = 'completed'
-                WHERE a.status = 'active'
-                  AND a.endTime <= :now
-            """)
-    int updateStatusToCompleted(@Param("now") LocalDateTime now);
-
     @Query("""
             SELECT 
                  a.id AS auctionId, 
@@ -168,4 +150,8 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
     DashboardProjection getDashboardCounts();
 
     List<AuctionStatus> status(AuctionStatus status);
+
+    List<Auction> findByStatusAndStartTimeBefore(AuctionStatus status, LocalDateTime startTimeBefore);
+
+    List<Auction> findByStatusAndEndTimeBefore(AuctionStatus status, LocalDateTime endTimeBefore);
 }

--- a/src/main/java/com/samyookgoo/palgoosam/auction/scheduler/AuctionStatusScheduler.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/scheduler/AuctionStatusScheduler.java
@@ -1,7 +1,13 @@
 package com.samyookgoo.palgoosam.auction.scheduler;
 
+import com.samyookgoo.palgoosam.auction.constant.AuctionStatus;
+import com.samyookgoo.palgoosam.auction.domain.Auction;
 import com.samyookgoo.palgoosam.auction.repository.AuctionRepository;
 import java.time.LocalDateTime;
+import java.util.List;
+
+import com.samyookgoo.palgoosam.auction.service.AuctionStatusService;
+import com.samyookgoo.palgoosam.schedule.AuctionStatusPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -13,16 +19,24 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class AuctionStatusScheduler {
     private final AuctionRepository auctionRepository;
+    private final AuctionStatusService auctionStatusService;
+    private final AuctionStatusPublisher statusPublisher;
 
-    @Scheduled(fixedDelay = 60000)  // 1분마다 실행
+    @Scheduled(fixedRate = 60000)  // 1분마다 실행
     @Transactional
-    public void updateAuctionStatus() {
+    public void FallbackAuctionStatus() {
         LocalDateTime now = LocalDateTime.now();
 
-        int activeUpdated = auctionRepository.updateStatusToActive(now);
-        int completedUpdated = auctionRepository.updateStatusToCompleted(now);
+        List<Auction> shouldBeActive = auctionRepository.findByStatusAndStartTimeBefore(AuctionStatus.pending, now);
+        for(Auction auction : shouldBeActive) {
+            auctionStatusService.updateStatusToActive(auction);
+            statusPublisher.publishStatus(auction.getId(), AuctionStatus.active);
+        }
 
-        log.info("경매 상태 업데이트: ACTIVE {}건", activeUpdated);
-        log.info("경매 상태 업데이트: COMPLETED {}건", completedUpdated);
+        List<Auction> shouldBeCompleted = auctionRepository.findByStatusAndEndTimeBefore(AuctionStatus.active, now);
+        for(Auction auction : shouldBeCompleted) {
+            auctionStatusService.updateStatusToCompleted(auction);
+            statusPublisher.publishStatus(auction.getId(), AuctionStatus.completed);
+        }
     }
 }

--- a/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionStatusService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionStatusService.java
@@ -1,0 +1,44 @@
+package com.samyookgoo.palgoosam.auction.service;
+
+import com.samyookgoo.palgoosam.auction.constant.AuctionStatus;
+import com.samyookgoo.palgoosam.auction.domain.Auction;
+import com.samyookgoo.palgoosam.auction.repository.AuctionRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class AuctionStatusService {
+    private final AuctionRepository auctionRepository;
+
+    @Transactional
+    public void updateStatusToActive(Long auctionId) {
+        auctionRepository.findById(auctionId).ifPresentOrElse(auction -> {
+            auction.setStatus(AuctionStatus.active);
+        }, () -> {
+            log.warn("존재하지 않는 auctionId: {}", auctionId);
+        });
+    }
+
+    @Transactional
+    public void updateStatusToCompleted(Long auctionId) {
+        auctionRepository.findById(auctionId).ifPresentOrElse(auction -> {
+            auction.setStatus(AuctionStatus.completed);
+        }, () -> {
+            log.warn("존재하지 않는 auctionId: {}", auctionId);
+        });
+    }
+
+    @Transactional
+    public void updateStatusToActive(Auction auction) {
+        auction.setStatus(AuctionStatus.active);
+    }
+
+    @Transactional
+    public void updateStatusToCompleted(Auction auction) {
+        auction.setStatus(AuctionStatus.completed);
+    }
+}

--- a/src/main/java/com/samyookgoo/palgoosam/bid/service/SseService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/service/SseService.java
@@ -6,21 +6,26 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.*;
+
+import com.samyookgoo.palgoosam.schedule.AuctionStatusEventResponse;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Service
 public class SseService {
-    private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+    private final Map<Long, List<SseEmitter>> bidEmitters = new ConcurrentHashMap<>();
+    private final ScheduledExecutorService heartbeatExecutor = Executors.newScheduledThreadPool(1);
 
     public SseEmitter subscribe(Long auctionId) {
         SseEmitter emitter = new SseEmitter(Duration.ofMinutes(30).toMillis());
-        emitters.computeIfAbsent(auctionId, id -> new CopyOnWriteArrayList<>()).add(emitter);
+        bidEmitters.computeIfAbsent(auctionId, id -> new CopyOnWriteArrayList<>()).add(emitter);
 
         emitter.onCompletion(() -> removeEmitter(auctionId, emitter));
         emitter.onTimeout(() -> removeEmitter(auctionId, emitter));
+        emitter.onError((ex) -> removeEmitter(auctionId, emitter));
 
         try {
             emitter.send(SseEmitter.event().name("connect").data("connected"));
@@ -32,7 +37,7 @@ public class SseService {
     }
 
     public void broadcastBidUpdate(Long auctionId, BidEventResponse response) {
-        List<SseEmitter> sseEmitters = emitters.getOrDefault(auctionId, new ArrayList<>());
+        List<SseEmitter> sseEmitters = bidEmitters.getOrDefault(auctionId, new ArrayList<>());
         List<SseEmitter> deadEmitters = new ArrayList<>();
 
         sseEmitters.forEach(emitter -> {
@@ -49,7 +54,47 @@ public class SseService {
         sseEmitters.removeAll(deadEmitters);
     }
 
+    public void broadcastStatusUpdate(Long auctionId, AuctionStatusEventResponse response) {
+        List<SseEmitter> sseEmitters = bidEmitters.getOrDefault(auctionId, new ArrayList<>());
+        List<SseEmitter> deadEmitters = new ArrayList<>();
+
+        sseEmitters.forEach(emitter -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("status-update")
+                        .data(response));
+            } catch (IOException e) {
+                emitter.completeWithError(e);
+                deadEmitters.add(emitter);
+            }
+        });
+        sseEmitters.removeAll(deadEmitters);
+    }
+
     private void removeEmitter(Long auctionId, SseEmitter emitter) {
-        emitters.getOrDefault(auctionId, List.of()).remove(emitter);
+        bidEmitters.getOrDefault(auctionId, List.of()).remove(emitter);
+    }
+
+    @PostConstruct
+    public void initHeartbeat() {
+        heartbeatExecutor.scheduleAtFixedRate(() -> {
+            bidEmitters.forEach((auctionId, emitterList) -> {
+                List<SseEmitter> deadEmitters = new ArrayList<>();
+                for (SseEmitter emitter : emitterList) {
+                    try {
+                        emitter.send(SseEmitter.event().comment("heartbeat"));
+                    } catch (IOException e) {
+                        emitter.completeWithError(e);
+                        deadEmitters.add(emitter);
+                    }
+                }
+                emitterList.removeAll(deadEmitters); // 끊긴 emitter 제거
+            });
+        }, 0, 30, TimeUnit.SECONDS); // 30초 간격
+    }
+
+    @PreDestroy
+    public void shutdownHeartbeatExecutor() {
+        heartbeatExecutor.shutdown();
     }
 }

--- a/src/main/java/com/samyookgoo/palgoosam/schedule/AuctionStatusEventResponse.java
+++ b/src/main/java/com/samyookgoo/palgoosam/schedule/AuctionStatusEventResponse.java
@@ -1,0 +1,11 @@
+package com.samyookgoo.palgoosam.schedule;
+
+import com.samyookgoo.palgoosam.auction.constant.AuctionStatus;
+
+import java.time.LocalDateTime;
+
+public record AuctionStatusEventResponse(
+        Long auctionId,
+        AuctionStatus status,
+        LocalDateTime timestamp
+) {}

--- a/src/main/java/com/samyookgoo/palgoosam/schedule/AuctionStatusPayload.java
+++ b/src/main/java/com/samyookgoo/palgoosam/schedule/AuctionStatusPayload.java
@@ -1,0 +1,8 @@
+package com.samyookgoo.palgoosam.schedule;
+
+import com.samyookgoo.palgoosam.auction.constant.AuctionStatus;
+
+public record AuctionStatusPayload(
+        Long auctionId,
+        AuctionStatus status
+) {}

--- a/src/main/java/com/samyookgoo/palgoosam/schedule/AuctionStatusPublisher.java
+++ b/src/main/java/com/samyookgoo/palgoosam/schedule/AuctionStatusPublisher.java
@@ -1,0 +1,21 @@
+package com.samyookgoo.palgoosam.schedule;
+
+import com.samyookgoo.palgoosam.auction.constant.AuctionStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuctionStatusPublisher {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ChannelTopic auctionStatusTopic;
+
+    public void publishStatus(Long auctionId, AuctionStatus status) {
+        AuctionStatusPayload payload = new AuctionStatusPayload(auctionId, status);
+        redisTemplate.convertAndSend(auctionStatusTopic.getTopic(), payload);
+    }
+}

--- a/src/main/java/com/samyookgoo/palgoosam/schedule/AuctionStatusSubscriber.java
+++ b/src/main/java/com/samyookgoo/palgoosam/schedule/AuctionStatusSubscriber.java
@@ -1,0 +1,46 @@
+package com.samyookgoo.palgoosam.schedule;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.samyookgoo.palgoosam.auction.constant.AuctionStatus;
+import com.samyookgoo.palgoosam.bid.service.SseService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuctionStatusSubscriber implements MessageListener {
+    private final SseService sseService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String json = new String(message.getBody(), StandardCharsets.UTF_8);
+            AuctionStatusPayload payload = objectMapper.readValue(json, AuctionStatusPayload.class);
+
+            Long auctionId = payload.auctionId();
+            AuctionStatus status = payload.status();
+            AuctionStatusEventResponse event = new AuctionStatusEventResponse(
+                    auctionId,
+                    status,
+                    LocalDateTime.now()
+            );
+
+            sseService.broadcastStatusUpdate(auctionId, event);
+            log.info("🔔 상태 전환 이벤트 수신 → auctionId={}, status={}", auctionId, status);
+
+
+        } catch (JsonProcessingException e) {
+            log.error("pub/sub 메시지 json 파싱 실패", e);
+        }
+
+    }
+}

--- a/src/main/java/com/samyookgoo/palgoosam/schedule/AuctionStatusSubscriber.java
+++ b/src/main/java/com/samyookgoo/palgoosam/schedule/AuctionStatusSubscriber.java
@@ -35,7 +35,7 @@ public class AuctionStatusSubscriber implements MessageListener {
             );
 
             sseService.broadcastStatusUpdate(auctionId, event);
-            log.info("🔔 상태 전환 이벤트 수신 → auctionId={}, status={}", auctionId, status);
+            log.info("@@@@@ 상태 전환 이벤트 수신 auctionId={}, status={}", auctionId, status);
 
 
         } catch (JsonProcessingException e) {

--- a/src/main/java/com/samyookgoo/palgoosam/schedule/JacksonConfig.java
+++ b/src/main/java/com/samyookgoo/palgoosam/schedule/JacksonConfig.java
@@ -1,0 +1,19 @@
+package com.samyookgoo.palgoosam.schedule;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class JacksonConfig {
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+}

--- a/src/main/java/com/samyookgoo/palgoosam/schedule/RedisConfig.java
+++ b/src/main/java/com/samyookgoo/palgoosam/schedule/RedisConfig.java
@@ -1,0 +1,46 @@
+package com.samyookgoo.palgoosam.schedule;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+
+        StringRedisSerializer keySerializer = new StringRedisSerializer();
+        GenericJackson2JsonRedisSerializer valueSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        template.setKeySerializer(keySerializer);
+        template.setValueSerializer(valueSerializer);
+        template.setHashKeySerializer(keySerializer);
+        template.setHashValueSerializer(valueSerializer);
+        template.afterPropertiesSet();
+
+        return template;
+    }
+
+    @Bean
+    public ChannelTopic auctionStatusTopic() {
+        return new ChannelTopic("auction:status");
+    }
+}

--- a/src/main/java/com/samyookgoo/palgoosam/schedule/RedisKeyExpirationListener.java
+++ b/src/main/java/com/samyookgoo/palgoosam/schedule/RedisKeyExpirationListener.java
@@ -25,7 +25,7 @@ public class RedisKeyExpirationListener extends KeyExpirationEventMessageListene
     @Override
     public void onMessage(Message message, byte[] pattern) {
         String expiredKey = message.toString();
-        log.info("⏰ Redis 키 만료 이벤트 수신: {}", expiredKey);
+        log.info("@@@@@ Redis 키 만료 이벤트 수신: {}", expiredKey);
 
         if (expiredKey.startsWith("auction:trigger:start:")) {
             Long id = Long.parseLong(expiredKey.split(":")[3]);

--- a/src/main/java/com/samyookgoo/palgoosam/schedule/RedisKeyExpirationListener.java
+++ b/src/main/java/com/samyookgoo/palgoosam/schedule/RedisKeyExpirationListener.java
@@ -1,0 +1,41 @@
+package com.samyookgoo.palgoosam.schedule;
+
+import com.samyookgoo.palgoosam.auction.constant.AuctionStatus;
+import com.samyookgoo.palgoosam.auction.service.AuctionStatusService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.listener.KeyExpirationEventMessageListener;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Slf4j
+public class RedisKeyExpirationListener extends KeyExpirationEventMessageListener {
+    private final AuctionStatusService auctionStatusService;
+    private final AuctionStatusPublisher auctionPublisher;
+
+    public RedisKeyExpirationListener(
+            RedisMessageListenerContainer listenerContainer,
+            AuctionStatusService auctionStatusService,
+            AuctionStatusPublisher auctionPublisher
+    ) {
+        super(listenerContainer);
+        this.auctionStatusService = auctionStatusService;
+        this.auctionPublisher = auctionPublisher;
+    }
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String expiredKey = message.toString();
+        log.info("⏰ Redis 키 만료 이벤트 수신: {}", expiredKey);
+
+        if (expiredKey.startsWith("auction:trigger:start:")) {
+            Long id = Long.parseLong(expiredKey.split(":")[3]);
+            auctionStatusService.updateStatusToActive(id);
+            auctionPublisher.publishStatus(id, AuctionStatus.active);
+        }
+        else if (expiredKey.startsWith("auction:trigger:end:")) {
+            Long id = Long.parseLong(expiredKey.split(":")[3]);
+            auctionStatusService.updateStatusToCompleted(id);
+            auctionPublisher.publishStatus(id, AuctionStatus.completed);
+        }
+    }
+}

--- a/src/main/java/com/samyookgoo/palgoosam/schedule/RedisListenerConfig.java
+++ b/src/main/java/com/samyookgoo/palgoosam/schedule/RedisListenerConfig.java
@@ -1,0 +1,46 @@
+package com.samyookgoo.palgoosam.schedule;
+
+import com.samyookgoo.palgoosam.auction.service.AuctionStatusService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class RedisListenerConfig {
+    private final RedisConnectionFactory connectionFactory;
+    private final AuctionStatusService auctionStatusService;
+    private final AuctionStatusPublisher statusPublisher;
+    private final AuctionStatusSubscriber statusSubscriber;
+    private final ChannelTopic auctionStatusTopic;
+
+    @Bean
+    public RedisMessageListenerContainer redisContainer() {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+
+        MessageListenerAdapter adapter = new MessageListenerAdapter(statusSubscriber, "onMessage");
+
+        adapter.setSerializer(new GenericJackson2JsonRedisSerializer());
+        container.addMessageListener(adapter, auctionStatusTopic);
+
+        return container;
+    }
+
+    @Bean
+    public RedisKeyExpirationListener rediskeyExpirationListener(RedisMessageListenerContainer container) {
+        RedisKeyExpirationListener listener =
+                new RedisKeyExpirationListener(container, auctionStatusService, statusPublisher);
+
+        container.addMessageListener(listener, new PatternTopic("__keyevent@*__:expired"));
+        return listener;
+    }
+}


### PR DESCRIPTION
### ✅  PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 🎯요약(Summary)
경매 상태 전환 스케줄링 고도화

### 💻 상세 내용(Describe your changes)
기존에는 스케줄러가 1분마다 실행되며 현재 시간과 경매 시작/종료 시간을 비교해,
- 경매 시작 시간이 지나면 상태를 pending → active,
- 종료 시간이 지나면 active → completed로 변경하는 방식이었습니다.

이번 스케줄링 고도화에서는 Redis TTL과 Pub/Sub 방식을 도입하여,
- TTL 키가 만료되는 시점에 경매 상태가 즉시 전환되고,
- 해당 상태 변경 내용을 Pub/Sub 메시지로 발행해,
- SSE를 통해 프론트엔드에 실시간 전달하도록 개선하였습니다.

또한, TTL 기반 전환이 누락되거나 실패할 경우를 대비해 1분 주기 폴백 스케줄러를 함께 운영하여 안정성과 일관성을 보장합니다.

### 📌 관련 이슈번호(Related Issue)
close #262 