### PR TITLE
Feat: 홈화면 최근 7일 이내 낙찰가 top 5 성능 개선

### DIFF
--- a/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionRepository.java
@@ -40,7 +40,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
                  ai.url AS thumbnailUrl, 
                  a.startTime AS startTime
             FROM Auction a
-            LEFT JOIN AuctionImage ai ON ai.auction.id = a.id AND ai.imageSeq = 0
+            JOIN AuctionImage ai ON ai.auction.id = a.id AND ai.imageSeq = 0
             WHERE a.status = :status AND a.startTime > CURRENT_TIMESTAMP
             ORDER BY a.startTime ASC
             """)
@@ -55,7 +55,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
                 a.basePrice AS basePrice,
                 ai.url AS thumbnailUrl
             FROM Auction a
-            LEFT JOIN AuctionImage ai ON ai.auction.id = a.id AND ai.imageSeq = 0
+            JOIN AuctionImage ai ON ai.auction.id = a.id AND ai.imageSeq = 0
             WHERE a.status IN :statuses
             ORDER BY a.createdAt DESC
             """)
@@ -66,7 +66,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             SELECT a.id AS auctionId, a.title AS title, a.description AS description,
                    a.itemCondition AS itemCondition, img.url AS thumbnailUrl
             FROM Auction a
-            LEFT JOIN AuctionImage img ON img.auction.id = a.id AND img.imageSeq = 0
+            JOIN AuctionImage img ON img.auction.id = a.id AND img.imageSeq = 0
             WHERE a.id IN :auctionIds
             """)
     List<RankingAuction> findRankingByIds(@Param("auctionIds") List<Long> auctionIds);
@@ -96,9 +96,10 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
                        img.url AS thumbnailUrl, a.startTime AS startTime
                 FROM Auction a
                 JOIN a.category c
-                JOIN c.parent mid
-                LEFT JOIN AuctionImage img ON img.auction.id = a.id AND img.imageSeq = 0
-                WHERE mid.id = :subCategoryId AND a.status IN ('pending', 'active')
+                JOIN c.parent sub
+                JOIN AuctionImage img ON img.auction.id = a.id AND img.imageSeq = 0
+                WHERE sub.id = :subCategoryId
+                    AND a.status IN ('pending', 'active')
                 ORDER BY (SELECT COUNT(s.id) FROM Scrap s WHERE s.auction.id = a.id) DESC, a.id ASC
             """)
     List<SubCategoryBestItem> findTop50BySubCategoryId(@Param("subCategoryId") Long subCategoryId, Pageable pageable);

--- a/src/main/java/com/samyookgoo/palgoosam/auction/scheduler/AuctionStatusScheduler.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/scheduler/AuctionStatusScheduler.java
@@ -22,7 +22,7 @@ public class AuctionStatusScheduler {
     private final AuctionStatusService auctionStatusService;
     private final AuctionStatusPublisher statusPublisher;
 
-    @Scheduled(fixedRate = 60000)  // 1분마다 실행
+    @Scheduled(fixedRate = 300000)  // 5분마다 실행
     @Transactional
     public void FallbackAuctionStatus() {
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/com/samyookgoo/palgoosam/auction/service/HomeService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/service/HomeService.java
@@ -85,10 +85,7 @@ public class HomeService {
 
     @Transactional(readOnly = true)
     public List<TopBidResponse> getTopBid() {
-        LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
-        Pageable topFive = PageRequest.of(0, 5);
-
-        List<TopWinningBid> topWinningBidList = bidRepository.findTop5WinningBids(sevenDaysAgo, topFive);
+        List<TopWinningBid> topWinningBidList = bidRepository.findTop5WinningBids();
 
         List<Long> auctionIds = topWinningBidList.stream()
                 .map(TopWinningBid::getAuctionId)

--- a/src/main/java/com/samyookgoo/palgoosam/bid/repository/BidRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/repository/BidRepository.java
@@ -71,7 +71,7 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
          ) AS b
              JOIN auction a ON a.id = b.auction_id
              JOIN user u ON u.id = b.bidder_id
-             LEFT JOIN auction_image img ON img.auction_id = a.id AND img.image_seq = 0
+             JOIN auction_image img ON img.auction_id = a.id AND img.image_seq = 0
     """, nativeQuery = true)
     List<TopWinningBid> findTop5WinningBids();
 

--- a/src/main/java/com/samyookgoo/palgoosam/bid/repository/BidRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/bid/repository/BidRepository.java
@@ -51,25 +51,29 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
     @Query("SELECT b.auction.id AS auctionId, COUNT(b.id) AS bidCount FROM Bid b WHERE b.auction.id IN :auctionIds GROUP BY b.auction.id")
     List<AuctionBidCount> countBidsByAuctionIds(@Param("auctionIds") List<Long> auctionIds);
 
-
-    @Query("""
-            SELECT
-                a.id AS auctionId,
-                a.title AS title,
-                a.basePrice AS basePrice,
-                MAX(b.price) AS itemPrice,
-                img.url AS thumbnailUrl,
-                b.bidder.name AS buyer
-            FROM Bid b
-            JOIN b.auction a
-            LEFT JOIN AuctionImage img ON img.auction.id = a.id AND img.imageSeq = 0
-            WHERE b.isWinning = true
-              AND a.status = 'COMPLETED'
-              AND a.endTime >= :sevenDaysAgo
-            GROUP BY a.id, a.title, a.basePrice, img.url, b.bidder.name
-            ORDER BY itemPrice DESC
-            """)
-    List<TopWinningBid> findTop5WinningBids(@Param("sevenDaysAgo") LocalDateTime sevenDaysAgo, Pageable pageable);
+    @Query(value = """
+    SELECT
+        b.auction_id AS auctionId,
+        a.title AS title,
+        a.base_price AS basePrice,
+        b.price AS itemPrice,
+        u.name AS buyer,
+        img.url AS thumbnailUrl
+    FROM (
+             SELECT b.auction_id, b.price, b.bidder_id
+             FROM bid b
+                      JOIN auction a ON b.auction_id = a.id
+             WHERE b.is_winning = true
+               AND a.status = 'COMPLETED'
+               AND a.end_time >= NOW() - INTERVAL 7 DAY
+             ORDER BY b.price DESC
+             LIMIT 5
+         ) AS b
+             JOIN auction a ON a.id = b.auction_id
+             JOIN user u ON u.id = b.bidder_id
+             LEFT JOIN auction_image img ON img.auction_id = a.id AND img.image_seq = 0
+    """, nativeQuery = true)
+    List<TopWinningBid> findTop5WinningBids();
 
     @Query("""
                 SELECT new com.samyookgoo.palgoosam.bid.service.response.BidStatsResponse(

--- a/src/main/java/com/samyookgoo/palgoosam/config/RedisListenerConfig.java
+++ b/src/main/java/com/samyookgoo/palgoosam/config/RedisListenerConfig.java
@@ -1,7 +1,10 @@
-package com.samyookgoo.palgoosam.schedule;
+package com.samyookgoo.palgoosam.config;
 
 import com.samyookgoo.palgoosam.auction.service.AuctionStatusService;
 import com.samyookgoo.palgoosam.common.event.LockReleaseSubscriber;
+import com.samyookgoo.palgoosam.schedule.AuctionStatusPublisher;
+import com.samyookgoo.palgoosam.schedule.AuctionStatusSubscriber;
+import com.samyookgoo.palgoosam.schedule.RedisKeyExpirationListener;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;


### PR DESCRIPTION
### ✅  PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 🎯요약(Summary)
홈화면 최근 7일 이내 낙찰가 top 5 성능 개선

### 💻 상세 내용(Describe your changes)
- 문제
  - user → bid 방향으로 루프가 돌면서, bidder_id 기준으로 bid를 반복 조회
  - MAX(b.price) + GROUP BY + ORDER BY 때문에 임시 테이블 생성 및 full scan

- 해결
  - 방법1.`is_winning = true` + `auction.status = 'COMPLETED'` + `end_time >= NOW() - 7일`
              → 이후 상위 5건만 정렬 후 출력
  - 방법2. 복합 인덱스 사용

### 📌 관련 이슈번호(Related Issue)
close #265